### PR TITLE
data.ref: add XML schemas of "factura electrónica" 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,6 @@ include HISTORY.rst
 include LICENSE
 include README.rst
 recursive-include cl_sii *py
+recursive-include cl_sii/data/ref/factura_electronica/schema_dte *.xsd
+recursive-include cl_sii/data/ref/factura_electronica/schema_iecv *.xsd
 include cl_sii/py.typed

--- a/cl_sii/data/ref/factura_electronica/schema_dte/DTE_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schema_dte/DTE_v10.xsd
@@ -1,0 +1,5162 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--Esquema para documentos DTE.
+Fecha Actualizacion:  25/05/07 15:00
+
+Se incorporan dos nuevos Tipos de datos :
+FechaType		:  Fecha entre 2000-01-01 y 2050-12-31
+FechaHoraType :  FechaType + hora entre 00:00 y 23:59
+
+Fecha Actualizacion:  19-12-2007 16:21
+
+Totales Exportacion : acepta minimo 0 (incluye detalle)
+
+Fecha Actualizacion:  30-05-2011 12:00
+
+Descuento Recargo Global : se incorporar restricción en Tipo de Movimiento
+			   para que sea dato de largo 1
+
+  -->
+<xs:schema targetNamespace="http://www.sii.cl/SiiDte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:SiiDte="http://www.sii.cl/SiiDte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="SiiTypes_v10.xsd"/>
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsignature_v10.xsd"/>
+	<xs:element name="DTE" type="SiiDte:DTEDefType"/>
+	<xs:complexType name="DTEDefType">
+		<xs:annotation>
+			<xs:documentation>Documento Tributario Electronico</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="Documento">
+					<xs:annotation>
+						<xs:documentation>Informacion Tributaria del DTE</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="Encabezado">
+								<xs:annotation>
+									<xs:documentation>Identificacion y Totales del Documento</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="IdDoc">
+											<xs:annotation>
+												<xs:documentation>Identificacion del DTE</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="TipoDTE" type="SiiDte:DTEType">
+														<xs:annotation>
+															<xs:documentation>Tipo de DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="Folio" type="SiiDte:FolioType">
+														<xs:annotation>
+															<xs:documentation>Folio del Documento Electronico</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="FchEmis" type="SiiDte:FechaType">
+														<xs:annotation>
+															<xs:documentation>Fecha Emision Contable del DTE (AAAA-MM-DD)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="IndNoRebaja" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Nota de Credito sin Derecho a Descontar Debito</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:enumeration value="1">
+																	<xs:annotation>
+																		<xs:documentation>Nota de Credito sin Derecho a Descontar Debito</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TipoDespacho" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Indica Modo de Despacho de los Bienes que Acompanan al DTE</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:enumeration value="1">
+																	<xs:annotation>
+																		<xs:documentation>Despacho por Cuenta del Comprador</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="2">
+																	<xs:annotation>
+																		<xs:documentation>Despacho por Cuenta del Emisor a Instalaciones del Comprador</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="3">
+																	<xs:annotation>
+																		<xs:documentation>Despacho por Cuenta del Emisor a Otras Instalaciones</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="IndTraslado" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Incluido en Guias de Despacho para Especifiicar el Tipo de Traslado de Productos</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:enumeration value="1">
+																	<xs:annotation>
+																		<xs:documentation>Operacion Constituye Venta</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="2">
+																	<xs:annotation>
+																		<xs:documentation>Venta por Efectuar</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="3">
+																	<xs:annotation>
+																		<xs:documentation>Consignacion</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="4">
+																	<xs:annotation>
+																		<xs:documentation>Promocion  o Donacion (RUT Emisor = RUT Receptor)</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="5">
+																	<xs:annotation>
+																		<xs:documentation>Traslado Interno</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="6">
+																	<xs:annotation>
+																		<xs:documentation>Otros Traslados que no Constituyen Venta</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="7">
+																	<xs:annotation>
+																		<xs:documentation>Guia de Devolucion</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="8"/>
+																<xs:enumeration value="9"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TpoImpresion" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Tipo de impresión N (Normal)  o T (Ticket) </xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:length value="1"/>
+																<xs:enumeration value="N"/>
+																<xs:enumeration value="T"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="IndServicio" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Indica si Transaccion Corresponde a la Prestacion de un Servicio</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:enumeration value="1">
+																	<xs:annotation>
+																		<xs:documentation>Facturacion de Servicios Periodicos Domiciliarios</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="2">
+																	<xs:annotation>
+																		<xs:documentation>Facturacion de Otros Servicios Periodicos</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="3">
+																	<xs:annotation>
+																		<xs:documentation>Factura de Servicio</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="MntBruto" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Indica el Uso de Montos Brutos en Detalle</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:integer">
+																<xs:enumeration value="1">
+																	<xs:annotation>
+																		<xs:documentation>Monto de Lineas de Detalle  Corresponde a Valores Brutos (IVA + Impuestos Adicionales)</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="FmaPago" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Forma de Pago del DTE</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:enumeration value="1">
+																	<xs:annotation>
+																		<xs:documentation>Pago Contado</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="2">
+																	<xs:annotation>
+																		<xs:documentation>Pago Credito</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="3">
+																	<xs:annotation>
+																		<xs:documentation>Sin Costo</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="FmaPagExp" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Forma de Pago Exportación Tabla Formas de Pago de Aduanas</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="2"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="FchCancel" type="SiiDte:FechaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Fecha de Cancelacion del DTE (AAAA-MM-DD)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntCancel" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto Cancelado al   emitirse el documento</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="SaldoInsol" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Saldo Insoluto al       emitirse el documento</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntPagos" minOccurs="0" maxOccurs="30">
+														<xs:annotation>
+															<xs:documentation>Tabla de Montos de Pago</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="FchPago" type="SiiDte:FechaType">
+																	<xs:annotation>
+																		<xs:documentation>Fecha de Pago (AAAA-MM-DD)</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="MntPago" type="SiiDte:MontoType">
+																	<xs:annotation>
+																		<xs:documentation>Monto de Pago</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="GlosaPagos" minOccurs="0">
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="40"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="PeriodoDesde" type="SiiDte:FechaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Periodo de Facturacion - Desde (AAAA-MM-DD)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="PeriodoHasta" type="SiiDte:FechaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Periodo Facturacion - Hasta (AAAA-MM-DD)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MedioPago" type="SiiDte:MedioPagoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Medio de Pago</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TpoCtaPago" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Tipo Cuenta de Pago</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="10"/>
+																<xs:minLength value="5"/>
+																<xs:enumeration value="AHORRO"/>
+																<xs:enumeration value="CORRIENTE"/>
+																<xs:enumeration value="VISTA"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="NumCtaPago" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Número de la cuenta del pago</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="20"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="BcoPago" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Banco donde se realiza el pago</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="40"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TermPagoCdg" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Codigo del Termino de Pago Acordado</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="4"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TermPagoGlosa" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Términos del Pago - glosa</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="100"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TermPagoDias" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Dias de Acuerdo al Codigo de Termino de Pago</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="3"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="FchVenc" type="SiiDte:FechaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Fecha de Vencimiento del Pago (AAAA-MM-DD)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="Emisor">
+											<xs:annotation>
+												<xs:documentation>Datos del Emisor</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="RUTEmisor" type="SiiDte:RUTType">
+														<xs:annotation>
+															<xs:documentation>RUT del Emisor del DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="RznSoc">
+														<xs:annotation>
+															<xs:documentation>Nombre o Razon Social del Emisor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="SiiDte:RznSocLargaType"/>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="GiroEmis">
+														<xs:annotation>
+															<xs:documentation>Giro Comercial del Emisor Relevante para el DTE </xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="80"/>
+																<xs:minLength value="1"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="Telefono" minOccurs="0" maxOccurs="2">
+														<xs:annotation>
+															<xs:documentation>Telefono Emisor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="SiiDte:FonoType">
+																<xs:maxLength value="20"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CorreoEmisor" type="SiiDte:MailType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Correo Elect. de contacto en empresa del  receptor </xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="Acteco" maxOccurs="4">
+														<xs:annotation>
+															<xs:documentation>Codigo de Actividad Economica del Emisor Relevante para el DTE</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="6"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="GuiaExport" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Emisor de una Guía de despacho para Exportación </xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="CdgTraslado" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código Emisor Traslado Excepcional  </xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="1"/>
+																			<xs:enumeration value="1"/>
+																			<xs:enumeration value="2"/>
+																			<xs:enumeration value="3"/>
+																			<xs:enumeration value="4"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="FolioAut" type="SiiDte:NroResolType" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Folio Autorización ( N° de Resolución del SI)</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="FchAut" type="SiiDte:FechaType" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Fecha de emisión de la Resolución de autorización (AAAA-MM-DD)</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="Sucursal" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Sucursal que Emite el DTE</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="20"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CdgSIISucur" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Codigo de Sucursal Entregado por el SII</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="9"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="DirOrigen" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Direccion de Origen</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="70"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CmnaOrigen" type="SiiDte:ComunaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Comuna de Origen</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CiudadOrigen" type="SiiDte:CiudadType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Ciudad de Origen</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CdgVendedor" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Codigo del Vendedor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="60"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="IdAdicEmisor" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Identificador Adicional del Emisor </xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="20"/>
+																<xs:minLength value="1"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="RUTMandante" type="SiiDte:RUTType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>RUT a Cuenta de Quien se Emite el DTE</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="Receptor">
+											<xs:annotation>
+												<xs:documentation>Datos del Receptor</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="RUTRecep" type="SiiDte:RUTType">
+														<xs:annotation>
+															<xs:documentation>RUT del Receptor del DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CdgIntRecep" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Codigo Interno del Receptor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="20"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="RznSocRecep" type="SiiDte:RznSocLargaType">
+														<xs:annotation>
+															<xs:documentation>Nombre o Razon Social del Receptor</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="Extranjero" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Receptor Extranjero</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="NumId" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Num. Identif. Receptor Extranjero</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="20"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="Nacionalidad" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Nacionalidad Receptor Extranjero</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="3"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="GiroRecep" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Giro Comercial del Receptor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="40"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="Contacto" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Telefono o E-mail de Contacto del Receptor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="80"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CorreoRecep" type="SiiDte:MailType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Correo Elect. de contacto en empresa del  receptor </xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="DirRecep" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Direccion en la Cual se Envian los Productos o se Prestan los Servicios</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="70"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CmnaRecep" type="SiiDte:ComunaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Comuna de Recepcion</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CiudadRecep" type="SiiDte:CiudadType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Ciudad de Recepcion</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="DirPostal" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Direccion Postal</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="70"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CmnaPostal" type="SiiDte:ComunaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Comuna Postal</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CiudadPostal" type="SiiDte:CiudadType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Ciudad Postal</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="RUTSolicita" type="SiiDte:RUTType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>RUT que solicita el DTE en Venta a Publico</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="Transporte" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Informacion de Transporte de Mercaderias</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="Patente" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Patente del Vehiculo que Transporta los Bienes</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="8"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="RUTTrans" type="SiiDte:RUTType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>RUT del Transportista</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="Chofer" minOccurs="0">
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="RUTChofer" type="SiiDte:RUTType">
+																	<xs:annotation>
+																		<xs:documentation>RUT del Chofer</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="NombreChofer">
+																	<xs:annotation>
+																		<xs:documentation>Nombre del Chofer</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="30"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="DirDest" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Direccion de Destino</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="70"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CmnaDest" type="SiiDte:ComunaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Comuna de Destino</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CiudadDest" type="SiiDte:CiudadType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Ciudad de Destino</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="Aduana" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>documentos de Exportación y guías de despacho </xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="CodModVenta" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código según  tabla "Modalidad de Venta" de aduana</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="2"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="CodClauVenta" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código según  Tabla "Cláusula compra-venta" de  Aduana</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="2"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="TotClauVenta" type="SiiDte:Dec16_2Type" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Total  Cláusula de venta</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="CodViaTransp" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Indicar el Código de la vía de transporte utilizada para transportar la mercadería, según tabla Vías de Transporte de Aduana</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="2"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="NombreTransp" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Nombre o Identificación del Medio de Transporte</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="40"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="RUTCiaTransp" type="SiiDte:RUTType" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Rut Cía. Transportadora</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="NomCiaTransp" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Nombre Cía. Transportadora</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="40"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="IdAdicTransp" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Identificador Adicional Cía. Transportadora</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="20"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="Booking" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Numero de reserva del Operador</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="20"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="Operador" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código del Operador</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="20"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="CodPtoEmbarque" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código del puerto de embarque según tabla de Aduana </xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="4"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="IdAdicPtoEmb" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Identificador Adicional Puerto de Embarque</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="20"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="CodPtoDesemb" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código del puerto de desembarque según tabla de Aduana </xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="4"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="IdAdicPtoDesemb" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Identificador Adicional Puerto de Desembarque</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="20"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="Tara" minOccurs="0">
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="7"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="CodUnidMedTara" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código de la unidad de medida  según tabla de Aduana </xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="2"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="PesoBruto" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Sumatoria de los pesos brutos de todos los ítems del documento</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:decimal">
+																			<xs:totalDigits value="10"/>
+																			<xs:fractionDigits value="2"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="CodUnidPesoBruto" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código de la unidad de medida  según tabla de Aduana </xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="2"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="PesoNeto" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Sumatoria de los pesos netos de todos los ítems del documento</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:decimal">
+																			<xs:totalDigits value="10"/>
+																			<xs:fractionDigits value="2"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="CodUnidPesoNeto" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código de la unidad de medida  según tabla de Aduana </xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="2"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="TotItems" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Indique el total de items del documento</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="18"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="TotBultos" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Cantidad total de bultos que ampara el documento.</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="18"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="TipoBultos" minOccurs="0" maxOccurs="10">
+																	<xs:annotation>
+																		<xs:documentation>Tabla de descripción de los distintos tipos de bultos</xs:documentation>
+																	</xs:annotation>
+																	<xs:complexType>
+																		<xs:sequence>
+																			<xs:element name="CodTpoBultos" minOccurs="0">
+																				<xs:annotation>
+																					<xs:documentation>Código según  tabla "Tipos de Bultos" de aduana</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:positiveInteger">
+																						<xs:totalDigits value="3"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="CantBultos" minOccurs="0">
+																				<xs:annotation>
+																					<xs:documentation>Cantidad de Bultos </xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:positiveInteger">
+																						<xs:totalDigits value="10"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="Marcas" minOccurs="0">
+																				<xs:annotation>
+																					<xs:documentation>Identificación de marcas, cuando es distinto de contenedor</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:string">
+																						<xs:maxLength value="255"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="IdContainer" minOccurs="0">
+																				<xs:annotation>
+																					<xs:documentation>Se utiliza cuando el tipo de bulto es contenedor</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:string">
+																						<xs:maxLength value="25"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="Sello" minOccurs="0">
+																				<xs:annotation>
+																					<xs:documentation>Sello contenedor. Con digito verificador</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:string">
+																						<xs:maxLength value="20"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="EmisorSello" minOccurs="0">
+																				<xs:annotation>
+																					<xs:documentation>Nombre emisor sello</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:string">
+																						<xs:maxLength value="70"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																		</xs:sequence>
+																	</xs:complexType>
+																</xs:element>
+																<xs:element name="MntFlete" type="SiiDte:Dec14_4Type" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Monto del flete según moneda de venta</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="MntSeguro" type="SiiDte:Dec14_4Type" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Monto del seguro , según moneda de venta</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="CodPaisRecep" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código del país del receptor extranjero de la mercadería,
+según tabla Países aduana</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="3"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="CodPaisDestin" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código del país de destino extranjero de la mercadería,
+según tabla Países aduana</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="3"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="Totales">
+											<xs:annotation>
+												<xs:documentation>Montos Totales del DTE</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="MntNeto" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto Neto del DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntExe" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto Exento del DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntBase" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto Base Faenamiento Carne</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntMargenCom" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto Base de Márgenes de Comercialización. Monto informado</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TasaIVA" type="SiiDte:PctType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Tasa de IVA</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="IVA" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto de IVA del DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="IVAProp" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto del IVA propio</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="IVATerc" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto del IVA de Terceros</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="ImptoReten" minOccurs="0" maxOccurs="20">
+														<xs:annotation>
+															<xs:documentation>Impuestos y Retenciones Adicionales</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="TipoImp" type="SiiDte:ImpAdicDTEType">
+																	<xs:annotation>
+																		<xs:documentation>Tipo de Impuesto o Retencion Adicional</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="TasaImp" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Tasa de Impuesto o Retencion</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="SiiDte:PctType">
+																			<xs:maxInclusive value="100.00"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="MontoImp" type="SiiDte:MntImpType">
+																	<xs:annotation>
+																		<xs:documentation>Monto del Impuesto o Retencion</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="IVANoRet" type="SiiDte:MntImpType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>IVA No Retenido</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CredEC" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Credito Especial Empresas Constructoras</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="GrntDep" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Garantia por Deposito de Envases o Embalajes</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="Comisiones" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Comisiones y otros cargos es obligatoria para Liquidaciones Factura </xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="ValComNeto" type="SiiDte:MontoType" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor Neto Comisiones y Otros Cargos</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="ValComExe" type="SiiDte:MontoType" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Val. Comis. y Otros Cargos no Afectos o Exentos</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="ValComIVA" type="SiiDte:MontoType" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor IVA Comisiones y Otros Cargos  </xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="MntTotal" type="SiiDte:MontoType">
+														<xs:annotation>
+															<xs:documentation>Monto Total del DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MontoNF" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto No Facturable - Corresponde a Bienes o Servicios Facturados Previamente</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MontoPeriodo" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total de Ventas o Servicios del Periodo</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="SaldoAnterior" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Saldo Anterior - Puede ser Negativo o Positivo</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="VlrPagar" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Valor a Pagar Total del documento</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="OtraMoneda" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Otra Moneda </xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="TpoMoneda" type="SiiDte:TipMonType">
+														<xs:annotation>
+															<xs:documentation>Tipo Ottra moneda Tabla de Monedas  de Aduanas</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TpoCambio" type="SiiDte:Dec6_4Type" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Tipo de Cambio fijado por el Banco Central de Chile</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntNetoOtrMnda" type="SiiDte:Dec14_4Type" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto Neto del DTE en Otra Moneda  </xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntExeOtrMnda" type="SiiDte:Dec14_4Type" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto Exento del DTE en Otra Moneda  </xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntFaeCarneOtrMnda" type="SiiDte:Dec14_4Type" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto Base Faenamiento Carne en Otra Moneda  </xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntMargComOtrMnda" type="SiiDte:Dec14_4Type" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto Base de Márgenes de Comercialización. Monto informado</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="IVAOtrMnda" type="SiiDte:Dec14_4Type" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto de IVA del DTE en Otra Moneda</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="ImpRetOtrMnda" minOccurs="0" maxOccurs="20">
+														<xs:annotation>
+															<xs:documentation>Impuestos y Retenciones Adicionales</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="TipoImpOtrMnda" type="SiiDte:ImpAdicDTEType">
+																	<xs:annotation>
+																		<xs:documentation>Tipo de Impuesto o Retencion Adicional</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="TasaImpOtrMnda" type="SiiDte:PctType" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Tasa de Impuesto o Retencion</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="VlrImpOtrMnda" type="SiiDte:Dec14_4Type">
+																	<xs:annotation>
+																		<xs:documentation>Valor del impuesto o retención en otra moneda </xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="IVANoRetOtrMnda" type="SiiDte:Dec14_4Type" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>IVA no retenido Otra Moneda </xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntTotOtrMnda" type="SiiDte:Dec14_4Type">
+														<xs:annotation>
+															<xs:documentation>Monto Total Otra Moneda</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="Detalle" maxOccurs="60">
+								<xs:annotation>
+									<xs:documentation>Detalle de Itemes del Documento</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="NroLinDet">
+											<xs:annotation>
+												<xs:documentation>Numero Secuencial de Linea</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:maxInclusive value="99"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="CdgItem" minOccurs="0" maxOccurs="5">
+											<xs:annotation>
+												<xs:documentation>Codificacion del Item</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="TpoCodigo">
+														<xs:annotation>
+															<xs:documentation>Tipo de Codificacion</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="VlrCodigo">
+														<xs:annotation>
+															<xs:documentation>Valor del Codigo de Item, para la Codificacion Particular</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="35"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="IndExe" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Indicador de Exencion/Facturacion</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:enumeration value="1">
+														<xs:annotation>
+															<xs:documentation>El Producto o Servicio NO ESTA Afecto a IVA</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="2">
+														<xs:annotation>
+															<xs:documentation>El Producto o Servicio NO ES Facturable</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="3">
+														<xs:annotation>
+															<xs:documentation>Garantia por Deposito/Envase</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="4">
+														<xs:annotation>
+															<xs:documentation>El producto No Constituye Venta</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="5">
+														<xs:annotation>
+															<xs:documentation>Item a Rebajar</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="6">
+														<xs:annotation>
+															<xs:documentation>No facturables negativos</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="Retenedor" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Sólo para transacciones realizadas por agentes retenedores</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="IndAgente">
+														<xs:annotation>
+															<xs:documentation>Indicador Agente Retenedor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="1"/>
+																<xs:enumeration value="R"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="MntBaseFaena" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto Base Faenamiento</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntMargComer" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Márgenes de Comercialización</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="PrcConsFinal" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Precio Unitario Neto Consumidor Final</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="NmbItem">
+											<xs:annotation>
+												<xs:documentation>Nombre del Item</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="80"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="DscItem" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Descripcion del Item</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="1000"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="QtyRef" type="SiiDte:Dec12_6Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Cantidad para la Unidad de Medida de Referencia</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="UnmdRef" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Unidad de Medida de Referencia</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="4"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="PrcRef" type="SiiDte:Dec12_6Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Precio Unitario de Referencia para Unidad de Referencia</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="QtyItem" type="SiiDte:Dec12_6Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Cantidad del Item</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="Subcantidad" minOccurs="0" maxOccurs="5">
+											<xs:annotation>
+												<xs:documentation>Distribucion de la Cantidad</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="SubQty" type="SiiDte:Dec12_6Type">
+														<xs:annotation>
+															<xs:documentation>Cantidad  Distribuida</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="SubCod">
+														<xs:annotation>
+															<xs:documentation>Codigo Descriptivo de la Subcantidad</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="35"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="FchElabor" type="SiiDte:FechaType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Fecha Elaboracion del Item</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="FchVencim" type="SiiDte:FechaType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Fecha Vencimiento del Item</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="UnmdItem" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Unidad de Medida</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="4"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="PrcItem" type="SiiDte:Dec12_6Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Precio Unitario del Item en Pesos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="OtrMnda" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Precio del Item en Otra Moneda</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="PrcOtrMon" type="SiiDte:Dec12_6Type">
+														<xs:annotation>
+															<xs:documentation>Precio Unitario en Otra Moneda</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="Moneda">
+														<xs:annotation>
+															<xs:documentation>Codigo de Otra Moneda (Usar Codigos de Moneda del Banco Central)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="3"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="FctConv" type="SiiDte:Dec6_4Type" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Factor  para Conversion a Pesos</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="DctoOtrMnda" type="SiiDte:Dec14_4Type" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Descuento en Otra Moneda </xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="RecargoOtrMnda" type="SiiDte:Dec14_4Type" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Recargo en Otra Moneda</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MontoItemOtrMnda" type="SiiDte:Dec14_4Type" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Valor por línea de detalle en Otra Moneda</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="DescuentoPct" type="SiiDte:PctType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Porcentaje de Descuento</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="DescuentoMonto" type="SiiDte:MntImpType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Monto de Descuento</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="SubDscto" minOccurs="0" maxOccurs="5">
+											<xs:annotation>
+												<xs:documentation>Desglose del Descuento</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="TipoDscto" type="SiiDte:DineroPorcentajeType">
+														<xs:annotation>
+															<xs:documentation>Tipo de SubDescuento</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="ValorDscto" type="SiiDte:Dec16_2Type">
+														<xs:annotation>
+															<xs:documentation>Valor del SubDescuento</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="RecargoPct" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Porcentaje de Recargo</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="SiiDte:PctType">
+													<xs:maxInclusive value="999.99"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="RecargoMonto" type="SiiDte:MntImpType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Monto de Recargo</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="SubRecargo" minOccurs="0" maxOccurs="5">
+											<xs:annotation>
+												<xs:documentation>Desglose del Recargo</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="TipoRecargo" type="SiiDte:DineroPorcentajeType">
+														<xs:annotation>
+															<xs:documentation>Tipo de SubRecargo</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="ValorRecargo" type="SiiDte:Dec16_2Type">
+														<xs:annotation>
+															<xs:documentation>Valor de SubRecargo</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="CodImpAdic" type="SiiDte:ImpAdicDTEType" minOccurs="0" maxOccurs="2">
+											<xs:annotation>
+												<xs:documentation>Codigo de Impuesto Adicional o Retencion</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="MontoItem" type="SiiDte:MontoType">
+											<xs:annotation>
+												<xs:documentation>Monto por Linea de Detalle. Corresponde al Monto Neto, a menos que MntBruto Indique lo Contrario </xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="SubTotInfo" minOccurs="0" maxOccurs="20">
+								<xs:annotation>
+									<xs:documentation>Subtotales Informativos</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="NroSTI">
+											<xs:annotation>
+												<xs:documentation>Número de Subtotal </xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:maxInclusive value="99"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="GlosaSTI">
+											<xs:annotation>
+												<xs:documentation>Glosa</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="40"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="OrdenSTI" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Ubicación para Impresión </xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:maxInclusive value="99"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="SubTotNetoSTI" type="SiiDte:Dec16_2Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor Neto del Subtotal</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="SubTotIVASTI" type="SiiDte:Dec16_2Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor del IVA del Subtotal</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="SubTotAdicSTI" type="SiiDte:Dec16_2Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor de los Impuestos adicionales o específicos del Subtotal</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="SubTotExeSTI" type="SiiDte:Dec16_2Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor no Afecto o Exento del Subtotal</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="ValSubtotSTI" type="SiiDte:Dec16_2Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor de la línea de subtotal</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="LineasDeta" minOccurs="0" maxOccurs="60">
+											<xs:annotation>
+												<xs:documentation>TABLA de  Líneas de Detalle que se agrupan en el Subtotal</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger"/>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="DscRcgGlobal" minOccurs="0" maxOccurs="20">
+								<xs:annotation>
+									<xs:documentation>Descuentos y/o Recargos que afectan al total del Documento</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="NroLinDR" type="xs:positiveInteger">
+											<xs:annotation>
+												<xs:documentation>Numero Secuencial de Linea</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="TpoMov">
+											<xs:annotation>
+												<xs:documentation>Tipo de Movimiento</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:minLength value="1"/>
+													<xs:maxLength value="1"/>
+													<xs:enumeration value="D">
+														<xs:annotation>
+															<xs:documentation>Descuento</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="R">
+														<xs:annotation>
+															<xs:documentation>Recargo</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="GlosaDR" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Descripcion del Descuento o Recargo</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="45"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="TpoValor" type="SiiDte:DineroPorcentajeType">
+											<xs:annotation>
+												<xs:documentation>Unidad en que se Expresa el Valor</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="ValorDR" type="SiiDte:Dec16_2Type">
+											<xs:annotation>
+												<xs:documentation>Valor del Descuento o Recargo</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="ValorDROtrMnda" type="SiiDte:Dec14_4Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor en otra moneda</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="IndExeDR" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Indica si el D/R es No Afecto o No Facturable</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:enumeration value="1">
+														<xs:annotation>
+															<xs:documentation>Descuento/Recargo Global No Afecto</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="2">
+														<xs:annotation>
+															<xs:documentation>Descuento/Recargo No Facturable</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="Referencia" minOccurs="0" maxOccurs="40">
+								<xs:annotation>
+									<xs:documentation>Identificacion de otros documentos Referenciados por Documento</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="NroLinRef">
+											<xs:annotation>
+												<xs:documentation>Numero Secuencial de Linea de Referencia</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:maxInclusive value="99"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="TpoDocRef">
+											<xs:annotation>
+												<xs:documentation>Tipo de Documento de Referencia</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="3"/>
+													<xs:minLength value="1"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="IndGlobal" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Indica que se esta Referenciando un Conjunto de Documentos</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:nonNegativeInteger">
+													<xs:totalDigits value="1"/>
+													<xs:enumeration value="1">
+														<xs:annotation>
+															<xs:documentation>El Documento hace Referencia a un Conjunto de Documentos Tributarios del Mismo Tipo</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="FolioRef" type="SiiDte:FolioRType">
+											<xs:annotation>
+												<xs:documentation>Folio del Documento de Referencia</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="RUTOtr" type="SiiDte:RUTType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>RUT Otro Contribuyente</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="FchRef" type="SiiDte:FechaType">
+											<xs:annotation>
+												<xs:documentation>Fecha de la Referencia</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CodRef" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Tipo de Uso de la Referencia</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:enumeration value="1">
+														<xs:annotation>
+															<xs:documentation>Anula Documento de Referencia</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="2">
+														<xs:annotation>
+															<xs:documentation>Corrige Texto del Documento de Referencia</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="3">
+														<xs:annotation>
+															<xs:documentation>Corrige Montos</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="RazonRef" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Razon Explicita por la que se Referencia el Documento</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="90"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="Comisiones" minOccurs="0" maxOccurs="20">
+								<xs:annotation>
+									<xs:documentation>Comisiones y otros cargos es obligatoria para Liquidaciones Factura </xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="NroLinCom">
+											<xs:annotation>
+												<xs:documentation>Numero Secuencial de Linea</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:maxInclusive value="20"/>
+													<xs:minInclusive value="1"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="TipoMovim">
+											<xs:annotation>
+												<xs:documentation>C (comisión) u O (otros cargos)</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:minLength value="1"/>
+													<xs:enumeration value="C"/>
+													<xs:enumeration value="O"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="Glosa">
+											<xs:annotation>
+												<xs:documentation>Especificación de la comisión u otro  cargo</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="60"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="TasaComision" type="SiiDte:PctType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor porcentual de la comisión u otro cargo</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="ValComNeto" type="SiiDte:MontoType">
+											<xs:annotation>
+												<xs:documentation>Valor Neto Comisiones y Otros Cargos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="ValComExe" type="SiiDte:MontoType">
+											<xs:annotation>
+												<xs:documentation>Val. Comis. y Otros Cargos no Afectos o Exentos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="ValComIVA" type="SiiDte:MontoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor IVA Comisiones y Otros Cargos  </xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="TED">
+								<xs:annotation>
+									<xs:documentation>Timbre Electronico de DTE</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="DD">
+											<xs:annotation>
+												<xs:documentation>Datos Basicos de Documento</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="RE" type="SiiDte:RUTType">
+														<xs:annotation>
+															<xs:documentation>RUT Emisor</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TD" type="SiiDte:DTEType">
+														<xs:annotation>
+															<xs:documentation>Tipo DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="F" type="SiiDte:FolioType">
+														<xs:annotation>
+															<xs:documentation>Folio DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="FE" type="SiiDte:FechaType">
+														<xs:annotation>
+															<xs:documentation>Fecha Emision DTE en Formato AAAA-MM-DD</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="RR" type="SiiDte:RUTType">
+														<xs:annotation>
+															<xs:documentation>RUT Receptor</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="RSR">
+														<xs:annotation>
+															<xs:documentation>Razon Social Receptor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="40"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="MNT" type="xs:unsignedLong">
+														<xs:annotation>
+															<xs:documentation>Monto Total DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="IT1">
+														<xs:annotation>
+															<xs:documentation>Descripcion Primer Item de Detalle</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="40"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CAF">
+														<xs:annotation>
+															<xs:documentation>Codigo Autorizacion Folios</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="DA">
+																	<xs:annotation>
+																		<xs:documentation>Datos de Autorizacion de Folios</xs:documentation>
+																	</xs:annotation>
+																	<xs:complexType>
+																		<xs:sequence>
+																			<xs:element name="RE" type="SiiDte:RUTType">
+																				<xs:annotation>
+																					<xs:documentation>RUT Emisor</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																			<xs:element name="RS">
+																				<xs:annotation>
+																					<xs:documentation>Razon Social Emisor</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:string">
+																						<xs:minLength value="1"/>
+																						<xs:maxLength value="40"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="TD" type="SiiDte:DTEType">
+																				<xs:annotation>
+																					<xs:documentation>Tipo DTE</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																			<xs:element name="RNG">
+																				<xs:annotation>
+																					<xs:documentation>Rango Autorizado de Folios</xs:documentation>
+																				</xs:annotation>
+																				<xs:complexType>
+																					<xs:sequence>
+																						<xs:element name="D" type="SiiDte:FolioType">
+																							<xs:annotation>
+																								<xs:documentation>Folio Inicial (Desde)</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="H" type="SiiDte:FolioType">
+																							<xs:annotation>
+																								<xs:documentation>Folio Final (Hasta)</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																					</xs:sequence>
+																				</xs:complexType>
+																			</xs:element>
+																			<xs:element name="FA" type="SiiDte:FechaType">
+																				<xs:annotation>
+																					<xs:documentation>Fecha Autorizacion en Formato AAAA-MM-DD</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																			<xs:choice>
+																				<xs:element name="RSAPK">
+																					<xs:annotation>
+																						<xs:documentation>Clave Publica RSA del Solicitante</xs:documentation>
+																					</xs:annotation>
+																					<xs:complexType>
+																						<xs:sequence>
+																							<xs:element name="M" type="xs:base64Binary">
+																								<xs:annotation>
+																									<xs:documentation>Modulo RSA</xs:documentation>
+																								</xs:annotation>
+																							</xs:element>
+																							<xs:element name="E" type="xs:base64Binary">
+																								<xs:annotation>
+																									<xs:documentation>Exponente RSA</xs:documentation>
+																								</xs:annotation>
+																							</xs:element>
+																						</xs:sequence>
+																					</xs:complexType>
+																				</xs:element>
+																				<xs:element name="DSAPK">
+																					<xs:annotation>
+																						<xs:documentation>Clave Publica DSA del Solicitante</xs:documentation>
+																					</xs:annotation>
+																					<xs:complexType>
+																						<xs:sequence>
+																							<xs:element name="P" type="xs:base64Binary">
+																								<xs:annotation>
+																									<xs:documentation>Modulo Primo</xs:documentation>
+																								</xs:annotation>
+																							</xs:element>
+																							<xs:element name="Q" type="xs:base64Binary">
+																								<xs:annotation>
+																									<xs:documentation>Entero Divisor de P - 1</xs:documentation>
+																								</xs:annotation>
+																							</xs:element>
+																							<xs:element name="G" type="xs:base64Binary">
+																								<xs:annotation>
+																									<xs:documentation>Entero f(P, Q)</xs:documentation>
+																								</xs:annotation>
+																							</xs:element>
+																							<xs:element name="Y" type="xs:base64Binary">
+																								<xs:annotation>
+																									<xs:documentation>G**X mod P</xs:documentation>
+																								</xs:annotation>
+																							</xs:element>
+																						</xs:sequence>
+																					</xs:complexType>
+																				</xs:element>
+																			</xs:choice>
+																			<xs:element name="IDK" type="xs:long">
+																				<xs:annotation>
+																					<xs:documentation>Identificador de Llave</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																		</xs:sequence>
+																	</xs:complexType>
+																</xs:element>
+																<xs:element name="FRMA">
+																	<xs:annotation>
+																		<xs:documentation>Firma Digital (RSA) del SII Sobre DA</xs:documentation>
+																	</xs:annotation>
+																	<xs:complexType>
+																		<xs:simpleContent>
+																			<xs:extension base="xs:base64Binary">
+																				<xs:attribute name="algoritmo" type="xs:string" use="required" fixed="SHA1withRSA"/>
+																			</xs:extension>
+																		</xs:simpleContent>
+																	</xs:complexType>
+																</xs:element>
+															</xs:sequence>
+															<xs:attribute name="version" use="required" fixed="1.0"/>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="TSTED" type="SiiDte:FechaHoraType">
+														<xs:annotation>
+															<xs:documentation>TimeStamp de Generacion del Timbre</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="FRMT">
+											<xs:annotation>
+												<xs:documentation>Valor de Firma Digital  sobre DD</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:simpleContent>
+													<xs:extension base="xs:base64Binary">
+														<xs:attribute name="algoritmo" use="required">
+															<xs:simpleType>
+																<xs:restriction base="xs:string">
+																	<xs:enumeration value="SHA1withRSA"/>
+																	<xs:enumeration value="SHA1withDSA"/>
+																</xs:restriction>
+															</xs:simpleType>
+														</xs:attribute>
+													</xs:extension>
+												</xs:simpleContent>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+									<xs:attribute name="version" use="required" fixed="1.0"/>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="TmstFirma" type="SiiDte:FechaHoraType">
+								<xs:annotation>
+									<xs:documentation>Fecha y Hora en que se Firmo Digitalmente el Documento AAAA-MM-DDTHH:MI:SS</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="ID" type="xs:ID" use="required"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Liquidacion">
+					<xs:annotation>
+						<xs:documentation>Informacion Tributaria de Liquidaciones</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="Encabezado">
+								<xs:annotation>
+									<xs:documentation>Identificacion y Totales del Documento</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="IdDoc">
+											<xs:annotation>
+												<xs:documentation>Identificacion del DTE</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="TipoDTE" type="SiiDte:LIQType">
+														<xs:annotation>
+															<xs:documentation>Tipo de DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="Folio" type="SiiDte:FolioType">
+														<xs:annotation>
+															<xs:documentation>Folio del Documento Electronico</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="FchEmis" type="SiiDte:FechaType">
+														<xs:annotation>
+															<xs:documentation>Fecha Emision Contable del DTE (AAAA-MM-DD)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="IndServicio" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Indica si Transaccion Corresponde a la Prestacion de un Servicio</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:enumeration value="1">
+																	<xs:annotation>
+																		<xs:documentation>Facturacion de Servicios Periodicos Domiciliarios</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="2">
+																	<xs:annotation>
+																		<xs:documentation>Facturacion de Otros Servicios Periodicos</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="3">
+																	<xs:annotation>
+																		<xs:documentation>Factura de Servicio</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="MntBruto" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Indica el Uso de Montos Brutos en Detalle</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:integer">
+																<xs:enumeration value="1">
+																	<xs:annotation>
+																		<xs:documentation>Monto de Lineas de Detalle  Corresponde a Valores Brutos (IVA + Impuestos Adicionales)</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="FmaPago" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Forma de Pago del DTE</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:enumeration value="1">
+																	<xs:annotation>
+																		<xs:documentation>Pago Contado</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="2">
+																	<xs:annotation>
+																		<xs:documentation>Pago Credito</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="3">
+																	<xs:annotation>
+																		<xs:documentation>Sin Costo</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="FchCancel" type="SiiDte:FechaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Fecha de Cancelacion del DTE (AAAA-MM-DD)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntCancel" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto Cancelado al   emitirse el documento</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="SaldoInsol" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Saldo Insoluto al       emitirse el documento</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntPagos" minOccurs="0" maxOccurs="30">
+														<xs:annotation>
+															<xs:documentation>Tabla de Montos de Pago</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="FchPago" type="SiiDte:FechaType">
+																	<xs:annotation>
+																		<xs:documentation>Fecha de Pago (AAAA-MM-DD)</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="MntPago" type="SiiDte:MontoType">
+																	<xs:annotation>
+																		<xs:documentation>Monto de Pago</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="GlosaPagos" minOccurs="0">
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="40"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="PeriodoDesde" type="SiiDte:FechaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Periodo de Facturacion - Desde (AAAA-MM-DD)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="PeriodoHasta" type="SiiDte:FechaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Periodo Facturacion - Hasta (AAAA-MM-DD)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MedioPago" type="SiiDte:MedioPagoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Medio de Pago</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TpoCtaPago" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Tipo Cuenta de Pago</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="10"/>
+																<xs:minLength value="5"/>
+																<xs:enumeration value="AHORRO"/>
+																<xs:enumeration value="CORRIENTE"/>
+																<xs:enumeration value="VISTA"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="NumCtaPago" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Número de la cuenta del pago</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="20"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="BcoPago" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Banco donde se realiza el pago</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="40"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TermPagoCdg" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Codigo del Termino de Pago Acordado</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="4"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TermPagoGlosa" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Términos del Pago - glosa</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="100"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TermPagoDias" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Dias de Acuerdo al Codigo de Termino de Pago</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="3"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="FchVenc" type="SiiDte:FechaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Fecha de Vencimiento del Pago (AAAA-MM-DD)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="Emisor">
+											<xs:annotation>
+												<xs:documentation>Datos del Emisor</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="RUTEmisor" type="SiiDte:RUTType">
+														<xs:annotation>
+															<xs:documentation>RUT del Emisor del DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="RznSoc">
+														<xs:annotation>
+															<xs:documentation>Nombre o Razon Social del Emisor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="100"/>
+																<xs:minLength value="1"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="GiroEmis">
+														<xs:annotation>
+															<xs:documentation>Giro Comercial del Emisor Relevante para el DTE </xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="80"/>
+																<xs:minLength value="1"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="Telefono" minOccurs="0" maxOccurs="2">
+														<xs:annotation>
+															<xs:documentation>Telefono Emisor </xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="SiiDte:FonoType">
+																<xs:maxLength value="20"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CorreoEmisor" type="SiiDte:MailType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Correo Elect. de contacto en empresa del  receptor </xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="Acteco" maxOccurs="4">
+														<xs:annotation>
+															<xs:documentation>Codigo de Actividad Economica del Emisor Relevante para el DTE</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="6"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="Sucursal" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Sucursal que Emite el DTE</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="20"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CdgSIISucur" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Codigo de Sucursal Entregado por el SII</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="9"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="DirOrigen">
+														<xs:annotation>
+															<xs:documentation>Direccion de Origen</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="70"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CmnaOrigen" type="SiiDte:ComunaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Comuna de Origen</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CiudadOrigen" type="SiiDte:CiudadType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Ciudad de Origen</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CdgVendedor" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Codigo del Vendedor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="60"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="Receptor">
+											<xs:annotation>
+												<xs:documentation>Datos del Receptor</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="RUTRecep" type="SiiDte:RUTType">
+														<xs:annotation>
+															<xs:documentation>RUT del Receptor del DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CdgIntRecep" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Codigo Interno del Receptor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="20"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="RznSocRecep" type="SiiDte:RznSocLargaType">
+														<xs:annotation>
+															<xs:documentation>Nombre o Razon Social del Receptor</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="GiroRecep">
+														<xs:annotation>
+															<xs:documentation>Giro Comercial del Receptor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="40"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="Contacto" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Glosa con nombre o teléfono de contacto en empresa del  receptor </xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="80"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CorreoRecep" type="SiiDte:MailType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Correo Elect. de contacto en empresa del  receptor </xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="DirRecep">
+														<xs:annotation>
+															<xs:documentation>Direccion en la Cual se Envian los Productos o se Prestan los Servicios</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="70"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CmnaRecep" type="SiiDte:ComunaType">
+														<xs:annotation>
+															<xs:documentation>Comuna de Recepcion</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CiudadRecep" type="SiiDte:CiudadType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Ciudad de Recepcion</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="DirPostal" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Direccion Postal</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="70"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CmnaPostal" type="SiiDte:ComunaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Comuna Postal</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CiudadPostal" type="SiiDte:CiudadType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Ciudad Postal</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="Totales">
+											<xs:annotation>
+												<xs:documentation>Montos Totales del DTE</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="MntNeto" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto Neto del DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntExe" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto Exento del DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TasaIVA" type="SiiDte:PctType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Tasa de IVA</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="IVA" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto de IVA del DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="IVAProp" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto del IVA propio</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="IVATerc" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto del IVA de Terceros</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="ImptoReten" minOccurs="0" maxOccurs="20">
+														<xs:annotation>
+															<xs:documentation>Impuestos y Retenciones Adicionales</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="TipoImp" type="SiiDte:ImpAdicDTEType">
+																	<xs:annotation>
+																		<xs:documentation>Tipo de Impuesto o Retencion Adicional</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="TasaImp" type="SiiDte:PctType" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Tasa de Impuesto o Retencion</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="MontoImp" type="SiiDte:MntImpType">
+																	<xs:annotation>
+																		<xs:documentation>Monto del Impuesto o Retencion</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="Comisiones" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Comisiones y otros cargos es obligatoria para Liquidaciones Factura </xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="ValComNeto" type="SiiDte:ValorType" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor Neto Comisiones y Otros Cargos</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="ValComExe" type="SiiDte:ValorType" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Val. Comis. y Otros Cargos no Afectos o Exentos</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="ValComIVA" type="SiiDte:ValorType" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor IVA Comisiones y Otros Cargos  </xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="MntTotal" type="SiiDte:ValorType">
+														<xs:annotation>
+															<xs:documentation>Monto Total del DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MontoPeriodo" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total de Ventas o Servicios del Periodo</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="SaldoAnterior" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Saldo Anterior - Puede ser Negativo o Positivo</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="VlrPagar" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Valor a Pagar Total del documento</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="Detalle" maxOccurs="60">
+								<xs:annotation>
+									<xs:documentation>Detalle de Itemes del Documento</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="NroLinDet">
+											<xs:annotation>
+												<xs:documentation>Numero Secuencial de Linea</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:maxInclusive value="99"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="CdgItem" minOccurs="0" maxOccurs="5">
+											<xs:annotation>
+												<xs:documentation>Codificacion del Item</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="TpoCodigo">
+														<xs:annotation>
+															<xs:documentation>Tipo de Codificacion</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="VlrCodigo">
+														<xs:annotation>
+															<xs:documentation>Valor del Codigo de Item, para la Codificacion Particular</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="35"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="TpoDocLiq">
+											<xs:annotation>
+												<xs:documentation>Tipo de Documento que se Liquida</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:minLength value="1"/>
+													<xs:maxLength value="3"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="IndExe" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Indicador de Exencion/Facturacion</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:enumeration value="1">
+														<xs:annotation>
+															<xs:documentation>El Producto o Servicio NO ESTA Afecto a IVA</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="2">
+														<xs:annotation>
+															<xs:documentation>El Producto o Servicio NO ES Facturable</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="3">
+														<xs:annotation>
+															<xs:documentation>Garantia por Deposito/Envase</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="4">
+														<xs:annotation>
+															<xs:documentation>El producto No Constituye Venta</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="5">
+														<xs:annotation>
+															<xs:documentation>Item a Rebajar</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="6">
+														<xs:annotation>
+															<xs:documentation>No facturables negativos</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="NmbItem">
+											<xs:annotation>
+												<xs:documentation>Nombre del Item</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="80"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="DscItem" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Descripcion del Item</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="1000"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="QtyRef" type="SiiDte:Dec12_6Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Cantidad para la Unidad de Medida de Referencia</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="UnmdRef" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Unidad de Medida de Referencia</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="4"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="PrcRef" type="SiiDte:Dec12_6Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Precio Unitario de Referencia para Unidad de Referencia</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="QtyItem" type="SiiDte:Dec12_6Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Cantidad del Item</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="Subcantidad" minOccurs="0" maxOccurs="5">
+											<xs:annotation>
+												<xs:documentation>Distribucion de la Cantidad</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="SubQty" type="SiiDte:Dec12_6Type">
+														<xs:annotation>
+															<xs:documentation>Cantidad  Distribuida</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="SubCod">
+														<xs:annotation>
+															<xs:documentation>Codigo Descriptivo de la Subcantidad</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="35"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="FchElabor" type="SiiDte:FechaType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Fecha Elaboracion del Item</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="FchVencim" type="SiiDte:FechaType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Fecha Vencimiento del Item</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="UnmdItem" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Unidad de Medida</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="4"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="PrcItem" type="SiiDte:Dec12_6Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Precio Unitario del Item en Pesos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CodImpAdic" type="SiiDte:ImpAdicDTEType" minOccurs="0" maxOccurs="2">
+											<xs:annotation>
+												<xs:documentation>Codigo de Impuesto Adicional o Retencion</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="MontoItem" type="SiiDte:ValorType">
+											<xs:annotation>
+												<xs:documentation>Monto por Linea de Detalle. Corresponde al Monto Neto, a menos que MntBruto Indique lo Contrario </xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="SubTotInfo" minOccurs="0" maxOccurs="20">
+								<xs:annotation>
+									<xs:documentation>Subtotales Informativos</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="NroSTI">
+											<xs:annotation>
+												<xs:documentation>Número de Subtotal </xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:maxInclusive value="99"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="GlosaSTI">
+											<xs:annotation>
+												<xs:documentation>Glosa</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="40"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="OrdenSTI" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Ubicación para Impresión </xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:maxInclusive value="99"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="SubTotNetoSTI" type="SiiDte:Dec16_2Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor Neto del Subtotal</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="SubTotIVASTI" type="SiiDte:Dec16_2Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor del IVA del Subtotal</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="SubTotAdicSTI" type="SiiDte:Dec16_2Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor de los Impuestos adicionales o específicos del Subtotal</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="SubTotExeSTI" type="SiiDte:Dec16_2Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor no Afecto o Exento del Subtotal</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="ValSubtotSTI" type="SiiDte:Dec16_2Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor de la línea de subtotal</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="LineasDeta" minOccurs="0" maxOccurs="60">
+											<xs:annotation>
+												<xs:documentation>TABLA de  Líneas de Detalle que se agrupan en el Subtotal</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger"/>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="Referencia" minOccurs="0" maxOccurs="40">
+								<xs:annotation>
+									<xs:documentation>Identificacion de otros documentos Referenciados por Documento</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="NroLinRef">
+											<xs:annotation>
+												<xs:documentation>Numero Secuencial de Linea de Referencia</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:maxInclusive value="99"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="TpoDocRef">
+											<xs:annotation>
+												<xs:documentation>Tipo de Documento de Referencia</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="3"/>
+													<xs:minLength value="1"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="IndGlobal" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Indica que se esta Referenciando un Conjunto de Documentos</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:nonNegativeInteger">
+													<xs:totalDigits value="1"/>
+													<xs:enumeration value="1">
+														<xs:annotation>
+															<xs:documentation>El Documento hace Referencia a un Conjunto de Documentos Tributarios del Mismo Tipo</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="FolioRef" type="SiiDte:FolioRType">
+											<xs:annotation>
+												<xs:documentation>Folio del Documento de Referencia</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="FchRef" type="SiiDte:FechaType">
+											<xs:annotation>
+												<xs:documentation>Fecha de la Referencia</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CodRef" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Tipo de Uso de la Referencia</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:enumeration value="1">
+														<xs:annotation>
+															<xs:documentation>Anula Documento de Referencia</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="2">
+														<xs:annotation>
+															<xs:documentation>Corrige Texto del Documento de Referencia</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="3">
+														<xs:annotation>
+															<xs:documentation>Corrige Montos</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="RazonRef" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Razon Explicita por la que se Referencia el Documento</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="90"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="Comisiones" minOccurs="0" maxOccurs="20">
+								<xs:annotation>
+									<xs:documentation>Comisiones y otros cargos es obligatoria para Liquidaciones Factura </xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="NroLinCom">
+											<xs:annotation>
+												<xs:documentation>Numero Secuencial de Linea</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:maxInclusive value="20"/>
+													<xs:totalDigits value="2"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="TipoMovim">
+											<xs:annotation>
+												<xs:documentation>C (comisión) u O (otros cargos)</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:minLength value="1"/>
+													<xs:maxLength value="1"/>
+													<xs:enumeration value="C"/>
+													<xs:enumeration value="O"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="Glosa">
+											<xs:annotation>
+												<xs:documentation>Especificación de la comisión u otro  cargo</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="60"/>
+													<xs:minLength value="1"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="TasaComision" type="SiiDte:PctType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor porcentual de la comisión u otro cargo</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="ValComNeto" type="SiiDte:ValorType">
+											<xs:annotation>
+												<xs:documentation>Valor Neto Comisiones y Otros Cargos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="ValComExe" type="SiiDte:ValorType">
+											<xs:annotation>
+												<xs:documentation>Val. Comis. y Otros Cargos no Afectos o Exentos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="ValComIVA" type="SiiDte:ValorType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor IVA Comisiones y Otros Cargos  </xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="TED">
+								<xs:annotation>
+									<xs:documentation>Timbre Electronico de DTE</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="DD">
+											<xs:annotation>
+												<xs:documentation>Datos Basicos de Documento</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="RE" type="SiiDte:RUTType">
+														<xs:annotation>
+															<xs:documentation>RUT Emisor</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TD" type="SiiDte:LIQType">
+														<xs:annotation>
+															<xs:documentation>Tipo DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="F" type="SiiDte:FolioType">
+														<xs:annotation>
+															<xs:documentation>Folio DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="FE" type="SiiDte:FechaType">
+														<xs:annotation>
+															<xs:documentation>Fecha Emision DTE en Formato AAAA-MM-DD</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="RR" type="SiiDte:RUTType">
+														<xs:annotation>
+															<xs:documentation>RUT Receptor</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="RSR">
+														<xs:annotation>
+															<xs:documentation>Razon Social Receptor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="40"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="MNT" type="xs:unsignedLong">
+														<xs:annotation>
+															<xs:documentation>Monto Total DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="IT1">
+														<xs:annotation>
+															<xs:documentation>Descripcion Primer Item de Detalle</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="40"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CAF">
+														<xs:annotation>
+															<xs:documentation>Codigo Autorizacion Folios</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="DA">
+																	<xs:annotation>
+																		<xs:documentation>Datos de Autorizacion de Folios</xs:documentation>
+																	</xs:annotation>
+																	<xs:complexType>
+																		<xs:sequence>
+																			<xs:element name="RE" type="SiiDte:RUTType">
+																				<xs:annotation>
+																					<xs:documentation>RUT Emisor</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																			<xs:element name="RS" type="SiiDte:RznSocCortaType">
+																				<xs:annotation>
+																					<xs:documentation>Razon Social Emisor</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																			<xs:element name="TD" type="SiiDte:LIQType">
+																				<xs:annotation>
+																					<xs:documentation>Tipo DTE</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																			<xs:element name="RNG">
+																				<xs:annotation>
+																					<xs:documentation>Rango Autorizado de Folios</xs:documentation>
+																				</xs:annotation>
+																				<xs:complexType>
+																					<xs:sequence>
+																						<xs:element name="D" type="SiiDte:FolioType">
+																							<xs:annotation>
+																								<xs:documentation>Folio Inicial (Desde)</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="H" type="SiiDte:FolioType">
+																							<xs:annotation>
+																								<xs:documentation>Folio Final (Hasta)</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																					</xs:sequence>
+																				</xs:complexType>
+																			</xs:element>
+																			<xs:element name="FA" type="SiiDte:FechaType">
+																				<xs:annotation>
+																					<xs:documentation>Fecha Autorizacion en Formato AAAA-MM-DD</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																			<xs:choice>
+																				<xs:element name="RSAPK">
+																					<xs:annotation>
+																						<xs:documentation>Clave Publica RSA del Solicitante</xs:documentation>
+																					</xs:annotation>
+																					<xs:complexType>
+																						<xs:sequence>
+																							<xs:element name="M" type="xs:base64Binary">
+																								<xs:annotation>
+																									<xs:documentation>Modulo RSA</xs:documentation>
+																								</xs:annotation>
+																							</xs:element>
+																							<xs:element name="E" type="xs:base64Binary">
+																								<xs:annotation>
+																									<xs:documentation>Exponente RSA</xs:documentation>
+																								</xs:annotation>
+																							</xs:element>
+																						</xs:sequence>
+																					</xs:complexType>
+																				</xs:element>
+																				<xs:element name="DSAPK">
+																					<xs:annotation>
+																						<xs:documentation>Clave Publica DSA del Solicitante</xs:documentation>
+																					</xs:annotation>
+																					<xs:complexType>
+																						<xs:sequence>
+																							<xs:element name="P" type="xs:base64Binary">
+																								<xs:annotation>
+																									<xs:documentation>Modulo Primo</xs:documentation>
+																								</xs:annotation>
+																							</xs:element>
+																							<xs:element name="Q" type="xs:base64Binary">
+																								<xs:annotation>
+																									<xs:documentation>Entero Divisor de P - 1</xs:documentation>
+																								</xs:annotation>
+																							</xs:element>
+																							<xs:element name="G" type="xs:base64Binary">
+																								<xs:annotation>
+																									<xs:documentation>Entero f(P, Q)</xs:documentation>
+																								</xs:annotation>
+																							</xs:element>
+																							<xs:element name="Y" type="xs:base64Binary">
+																								<xs:annotation>
+																									<xs:documentation>G**X mod P</xs:documentation>
+																								</xs:annotation>
+																							</xs:element>
+																						</xs:sequence>
+																					</xs:complexType>
+																				</xs:element>
+																			</xs:choice>
+																			<xs:element name="IDK" type="xs:long">
+																				<xs:annotation>
+																					<xs:documentation>Identificador de Llave</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																		</xs:sequence>
+																	</xs:complexType>
+																</xs:element>
+																<xs:element name="FRMA">
+																	<xs:annotation>
+																		<xs:documentation>Firma Digital (RSA) del SII Sobre DA</xs:documentation>
+																	</xs:annotation>
+																	<xs:complexType>
+																		<xs:simpleContent>
+																			<xs:extension base="xs:base64Binary">
+																				<xs:attribute name="algoritmo" type="xs:string" use="required" fixed="SHA1withRSA"/>
+																			</xs:extension>
+																		</xs:simpleContent>
+																	</xs:complexType>
+																</xs:element>
+															</xs:sequence>
+															<xs:attribute name="version" use="required" fixed="1.0"/>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="TSTED" type="SiiDte:FechaHoraType">
+														<xs:annotation>
+															<xs:documentation>TimeStamp de Generacion del Timbre</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="FRMT">
+											<xs:annotation>
+												<xs:documentation>Valor de Firma Digital  sobre DD</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:simpleContent>
+													<xs:extension base="xs:base64Binary">
+														<xs:attribute name="algoritmo" use="required">
+															<xs:simpleType>
+																<xs:restriction base="xs:string">
+																	<xs:enumeration value="SHA1withRSA"/>
+																	<xs:enumeration value="SHA1withDSA"/>
+																</xs:restriction>
+															</xs:simpleType>
+														</xs:attribute>
+													</xs:extension>
+												</xs:simpleContent>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+									<xs:attribute name="version" use="required" fixed="1.0"/>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="TmstFirma" type="SiiDte:FechaHoraType">
+								<xs:annotation>
+									<xs:documentation>Fecha y Hora en que se Firmo Digitalmente el Documento AAAA-MM-DDTHH:MI:SS</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="ID" type="xs:ID" use="required"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Exportaciones">
+					<xs:annotation>
+						<xs:documentation>Informacion Tributaria de exportaciones</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="Encabezado">
+								<xs:annotation>
+									<xs:documentation>Identificacion y Totales del Documento</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="IdDoc">
+											<xs:annotation>
+												<xs:documentation>Identificacion del DTE</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="TipoDTE" type="SiiDte:EXPType">
+														<xs:annotation>
+															<xs:documentation>Tipo de DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="Folio" type="SiiDte:FolioType">
+														<xs:annotation>
+															<xs:documentation>Folio del Documento Electronico</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="FchEmis" type="SiiDte:FechaType">
+														<xs:annotation>
+															<xs:documentation>Fecha Emision Contable del DTE (AAAA-MM-DD)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TipoDespacho" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Indica Modo de Despacho de los Bienes que Acompanan al DTE</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:enumeration value="1">
+																	<xs:annotation>
+																		<xs:documentation>Despacho por Cuenta del Comprador</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="2">
+																	<xs:annotation>
+																		<xs:documentation>Despacho por Cuenta del Emisor a Instalaciones del Comprador</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="3">
+																	<xs:annotation>
+																		<xs:documentation>Despacho por Cuenta del Emisor a Otras Instalaciones</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="IndServicio" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Indica si Transaccion Corresponde a la Prestacion de un Servicio</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="1"/>
+																<xs:enumeration value="3">
+																	<xs:annotation>
+																		<xs:documentation>Factura de Servicio</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="4"/>
+																<xs:enumeration value="5"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="FmaPago" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Forma de Pago del DTE</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:enumeration value="1">
+																	<xs:annotation>
+																		<xs:documentation>Pago Contado</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="2">
+																	<xs:annotation>
+																		<xs:documentation>Pago Credito</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="3">
+																	<xs:annotation>
+																		<xs:documentation>Sin Costo</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="FmaPagExp" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Forma de Pago Exportación Tabla Formas de Pago de Aduanas</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="2"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="FchCancel" type="SiiDte:FechaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Fecha de Cancelacion del DTE (AAAA-MM-DD)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntCancel" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto Cancelado al   emitirse el documento</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="SaldoInsol" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Saldo Insoluto al       emitirse el documento</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntPagos" minOccurs="0" maxOccurs="30">
+														<xs:annotation>
+															<xs:documentation>Tabla de Montos de Pago</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="FchPago" type="SiiDte:FechaType">
+																	<xs:annotation>
+																		<xs:documentation>Fecha de Pago (AAAA-MM-DD)</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="MntPago" type="SiiDte:MontoType">
+																	<xs:annotation>
+																		<xs:documentation>Monto de Pago</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="GlosaPagos" minOccurs="0">
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="40"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="PeriodoDesde" type="SiiDte:FechaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Periodo de Facturacion - Desde (AAAA-MM-DD)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="PeriodoHasta" type="SiiDte:FechaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Periodo Facturacion - Hasta (AAAA-MM-DD)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MedioPago" type="SiiDte:MedioPagoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Medio de Pago</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TpoCtaPago" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Tipo Cuenta de Pago</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="10"/>
+																<xs:minLength value="5"/>
+																<xs:enumeration value="AHORRO"/>
+																<xs:enumeration value="CORRIENTE"/>
+																<xs:enumeration value="VISTA"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="NumCtaPago" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Número de la cuenta del pago</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="20"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="BcoPago" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Banco donde se realiza el pago</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="40"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TermPagoCdg" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Codigo del Termino de Pago Acordado</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="4"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TermPagoGlosa" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Términos del Pago - glosa</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="100"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TermPagoDias" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Dias de Acuerdo al Codigo de Termino de Pago</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="3"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="FchVenc" type="SiiDte:FechaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Fecha de Vencimiento del Pago (AAAA-MM-DD)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="Emisor">
+											<xs:annotation>
+												<xs:documentation>Datos del Emisor</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="RUTEmisor" type="SiiDte:RUTType">
+														<xs:annotation>
+															<xs:documentation>RUT del Emisor del DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="RznSoc">
+														<xs:annotation>
+															<xs:documentation>Nombre o Razon Social del Emisor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="100"/>
+																<xs:minLength value="1"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="GiroEmis">
+														<xs:annotation>
+															<xs:documentation>Giro Comercial del Emisor Relevante para el DTE </xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="80"/>
+																<xs:minLength value="1"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="Telefono" minOccurs="0" maxOccurs="2">
+														<xs:annotation>
+															<xs:documentation>Telefono Emisor </xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="SiiDte:FonoType">
+																<xs:maxLength value="20"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CorreoEmisor" type="SiiDte:MailType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Correo Elect. de contacto en empresa del  receptor </xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="Acteco" maxOccurs="4">
+														<xs:annotation>
+															<xs:documentation>Codigo de Actividad Economica del Emisor Relevante para el DTE</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="6"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="Sucursal" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Sucursal que Emite el DTE</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="20"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CdgSIISucur" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Codigo de Sucursal Entregado por el SII</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="9"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CodAdicSucur" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Sucursal que Emite el DTE</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="20"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="DirOrigen" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Direccion de Origen</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="70"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CmnaOrigen" type="SiiDte:ComunaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Comuna de Origen</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CiudadOrigen" type="SiiDte:CiudadType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Ciudad de Origen</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CdgVendedor" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Codigo del Vendedor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="60"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="IdAdicEmisor" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Identificador Adicional del Emisor </xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="20"/>
+																<xs:minLength value="1"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="Receptor">
+											<xs:annotation>
+												<xs:documentation>Datos del Receptor</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="RUTRecep" type="SiiDte:RUTType">
+														<xs:annotation>
+															<xs:documentation>RUT del Receptor del DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CdgIntRecep" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Codigo Interno del Receptor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="20"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="RznSocRecep" type="SiiDte:RznSocLargaType">
+														<xs:annotation>
+															<xs:documentation>Nombre o Razon Social del Receptor</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="Extranjero" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Receptor Extranjero</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="NumId" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Num. Identif. Receptor Extranjero</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="20"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="Nacionalidad" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Nacionalidad Receptor Extranjero</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="3"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="IdAdicRecep" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Identificador Adicional del Receptor  extranjero</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="20"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="GiroRecep" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Giro Comercial del Receptor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="40"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="Contacto" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Glosa con nombre o teléfono de contacto en empresa del  receptor </xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="80"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CorreoRecep" type="SiiDte:MailType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Correo Elect. de contacto en empresa del  receptor </xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="DirRecep" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Direccion en la Cual se Envian los Productos o se Prestan los Servicios</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="70"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CmnaRecep" type="SiiDte:ComunaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Comuna de Recepcion</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CiudadRecep" type="SiiDte:CiudadType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Ciudad de Recepcion</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="DirPostal" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Direccion Postal</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="70"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CmnaPostal" type="SiiDte:ComunaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Comuna Postal</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CiudadPostal" type="SiiDte:CiudadType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Ciudad Postal</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="Transporte" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Informacion de Transporte de Mercaderias</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="Patente" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Patente del Vehiculo que Transporta los Bienes</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="8"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="RUTTrans" type="SiiDte:RUTType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>RUT del Transportista</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="Chofer" minOccurs="0">
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="RUTChofer" type="SiiDte:RUTType">
+																	<xs:annotation>
+																		<xs:documentation>RUT del Chofer</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="NombreChofer">
+																	<xs:annotation>
+																		<xs:documentation>Nombre del Chofer</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="30"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="DirDest" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Direccion de Destino</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="70"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CmnaDest" type="SiiDte:ComunaType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Comuna de Destino</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CiudadDest" type="SiiDte:CiudadType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Ciudad de Destino</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="Aduana" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>documentos de Exportación y guías de despacho </xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="CodModVenta" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código según  tabla "Modalidad de Venta" de aduana</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="2"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="CodClauVenta" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código según  Tabla "Cláusula compra-venta" de  Aduana</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="2"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="TotClauVenta" type="SiiDte:Dec16_2Type" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Total  Cláusula de venta</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="CodViaTransp" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Indicar el Código de la vía de transporte utilizada para transportar la mercadería, según tabla Vías de Transporte de Aduana</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="2"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="NombreTransp" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Nombre o Identificación del Medio de Transporte</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="40"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="RUTCiaTransp" type="SiiDte:RUTType" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Rut Cía. Transportadora</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="NomCiaTransp" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Nombre Cía. Transportadora</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="40"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="IdAdicTransp" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Identificador Adicional Cía. Transportadora</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="20"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="Booking" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Numero de reserva del Operador</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="20"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="Operador" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código del Operador</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="20"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="CodPtoEmbarque" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código del puerto de embarque según tabla de Aduana </xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="4"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="IdAdicPtoEmb" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Identificador Adicional Puerto de Embarque</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="20"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="CodPtoDesemb" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código del puerto de desembarque según tabla de Aduana </xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="4"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="IdAdicPtoDesemb" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Identificador Adicional Puerto de Desembarque</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:maxLength value="20"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="Tara" minOccurs="0">
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="7"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="CodUnidMedTara" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código de la unidad de medida  según tabla de Aduana </xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="2"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="PesoBruto" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Sumatoria de los pesos brutos de todos los ítems del documento</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:decimal">
+																			<xs:totalDigits value="10"/>
+																			<xs:fractionDigits value="2"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="CodUnidPesoBruto" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código de la unidad de medida  según tabla de Aduana </xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="2"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="PesoNeto" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Sumatoria de los pesos netos de todos los ítems del documento</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:decimal">
+																			<xs:totalDigits value="10"/>
+																			<xs:fractionDigits value="2"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="CodUnidPesoNeto" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código de la unidad de medida  según tabla de Aduana </xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="2"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="TotItems" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Indique el total de items del documento</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="18"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="TotBultos" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Cantidad total de bultos que ampara el documento.</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="18"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="TipoBultos" minOccurs="0" maxOccurs="10">
+																	<xs:annotation>
+																		<xs:documentation>Tabla de descripción de los distintos tipos de bultos</xs:documentation>
+																	</xs:annotation>
+																	<xs:complexType>
+																		<xs:sequence>
+																			<xs:element name="CodTpoBultos" minOccurs="0">
+																				<xs:annotation>
+																					<xs:documentation>Código según  tabla "Tipos de Bultos" de aduana</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:positiveInteger">
+																						<xs:totalDigits value="3"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="CantBultos" minOccurs="0">
+																				<xs:annotation>
+																					<xs:documentation>Cantidad de Bultos </xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:positiveInteger">
+																						<xs:totalDigits value="10"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="Marcas" minOccurs="0">
+																				<xs:annotation>
+																					<xs:documentation>Identificación de marcas, cuando es distinto de contenedor</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:string">
+																						<xs:maxLength value="255"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="IdContainer" minOccurs="0">
+																				<xs:annotation>
+																					<xs:documentation>Se utiliza cuando el tipo de bulto es contenedor</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:string">
+																						<xs:maxLength value="25"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="Sello" minOccurs="0">
+																				<xs:annotation>
+																					<xs:documentation>Sello contenedor. Con digito verificador</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:string">
+																						<xs:maxLength value="20"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="EmisorSello" minOccurs="0">
+																				<xs:annotation>
+																					<xs:documentation>Nombre emisor sello</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:string">
+																						<xs:maxLength value="70"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																		</xs:sequence>
+																	</xs:complexType>
+																</xs:element>
+																<xs:element name="MntFlete" type="SiiDte:Dec14_4Type" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Monto del flete según moneda de venta</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="MntSeguro" type="SiiDte:Dec14_4Type" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Monto del seguro , según moneda de venta</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="CodPaisRecep" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código del país del receptor extranjero de la mercadería,
+según tabla Países aduana</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="3"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="CodPaisDestin" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código del país de destino extranjero de la mercadería,
+según tabla Países aduana</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="3"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="Totales">
+											<xs:annotation>
+												<xs:documentation>Montos Totales del DTE</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="TpoMoneda" type="SiiDte:TipMonType">
+														<xs:annotation>
+															<xs:documentation>Tipo de Moneda en que se regisrtra la transacción.  Tabla de Monedas  de Aduanas</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntExe">
+														<xs:annotation>
+															<xs:documentation>Monto Exento del DTE</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:decimal">
+																<xs:minInclusive value="0.0000"/>
+																<xs:maxInclusive value="99999999999999.9999"/>
+																<xs:totalDigits value="18"/>
+																<xs:fractionDigits value="4"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="MntTotal">
+														<xs:annotation>
+															<xs:documentation>Monto Total del DTE</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:decimal">
+																<xs:minInclusive value="0.0000"/>
+																<xs:maxInclusive value="99999999999999.9999"/>
+																<xs:totalDigits value="18"/>
+																<xs:fractionDigits value="4"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="OtraMoneda" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Otra Moneda </xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="TpoMoneda" type="SiiDte:TipMonType">
+														<xs:annotation>
+															<xs:documentation>Tipo Otra moneda Tabla de Monedas  de Aduanas</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TpoCambio" type="SiiDte:Dec6_4Type" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Tipo de Cambio fijado por el Banco Central de Chile</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntExeOtrMnda" type="SiiDte:Dec14_4Type" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Monto Exento del DTE en Otra Moneda  </xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntTotOtrMnda" type="SiiDte:Dec14_4Type">
+														<xs:annotation>
+															<xs:documentation>Monto Total Otra Moneda</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="Detalle" maxOccurs="60">
+								<xs:annotation>
+									<xs:documentation>Detalle de Itemes del Documento</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="NroLinDet">
+											<xs:annotation>
+												<xs:documentation>Numero Secuencial de Linea</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:maxInclusive value="99"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="CdgItem" minOccurs="0" maxOccurs="5">
+											<xs:annotation>
+												<xs:documentation>Codificacion del Item</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="TpoCodigo">
+														<xs:annotation>
+															<xs:documentation>Tipo de Codificacion</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="VlrCodigo">
+														<xs:annotation>
+															<xs:documentation>Valor del Codigo de Item, para la Codificacion Particular</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="35"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="IndExe" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Indicador de Exencion/Facturacion</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:enumeration value="1">
+														<xs:annotation>
+															<xs:documentation>El Producto o Servicio NO ESTA Afecto a IVA</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="2">
+														<xs:annotation>
+															<xs:documentation>El Producto o Servicio NO ES Facturable</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="3">
+														<xs:annotation>
+															<xs:documentation>Garantia por Deposito/Envase</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="4">
+														<xs:annotation>
+															<xs:documentation>El producto No Constituye Venta</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="5">
+														<xs:annotation>
+															<xs:documentation>Item a Rebajar</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="6">
+														<xs:annotation>
+															<xs:documentation>No facturables negativos</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="NmbItem">
+											<xs:annotation>
+												<xs:documentation>Nombre del Item</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="80"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="DscItem" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Descripcion del Item</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="1000"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="QtyRef" type="SiiDte:Dec12_6Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Cantidad para la Unidad de Medida de Referencia</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="UnmdRef" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Unidad de Medida de Referencia</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="4"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="PrcRef" type="SiiDte:Dec12_6Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Precio Unitario de Referencia para Unidad de Referencia</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="QtyItem" type="SiiDte:Dec12_6Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Cantidad del Item</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="Subcantidad" minOccurs="0" maxOccurs="5">
+											<xs:annotation>
+												<xs:documentation>Distribucion de la Cantidad</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="SubQty" type="SiiDte:Dec12_6Type">
+														<xs:annotation>
+															<xs:documentation>Cantidad  Distribuida</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="SubCod">
+														<xs:annotation>
+															<xs:documentation>Codigo Descriptivo de la Subcantidad</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="35"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TipCodSubQty" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Tipo de Código Subcantidad</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="10"/>
+																<xs:minLength value="1"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="FchElabor" type="SiiDte:FechaType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Fecha Elaboracion del Item</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="FchVencim" type="SiiDte:FechaType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Fecha Vencimiento del Item</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="UnmdItem" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Unidad de Medida</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="4"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="PrcItem" type="SiiDte:Dec12_6Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Precio Unitario del Item </xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="OtrMnda" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Precio del Item en Otra Moneda</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="PrcOtrMon" type="SiiDte:Dec14_4Type">
+														<xs:annotation>
+															<xs:documentation>Precio Unitario en Otra Moneda</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="Moneda">
+														<xs:annotation>
+															<xs:documentation>Codigo de Otra Moneda (Usar Codigos de Moneda del Banco Central)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:maxLength value="3"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="FctConv" type="SiiDte:Dec6_4Type" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Factor  para Conversion a Pesos</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="DctoOtrMnda" type="SiiDte:Dec14_4Type" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Descuento en Otra Moneda </xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="RecargoOtrMnda" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Recargo en Otra Moneda</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="SiiDte:Dec14_4Type">
+																<xs:totalDigits value="18"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="MontoItemOtrMnda">
+														<xs:annotation>
+															<xs:documentation>Valor por línea de detalle en Otra Moneda</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="SiiDte:Dec14_4Type">
+																<xs:totalDigits value="18"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="DescuentoPct" type="SiiDte:PctType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Porcentaje de Descuento</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="DescuentoMonto" type="SiiDte:MntImpType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Monto de Descuento</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="SubDscto" minOccurs="0" maxOccurs="5">
+											<xs:annotation>
+												<xs:documentation>Desglose del Descuento</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="TipoDscto">
+														<xs:annotation>
+															<xs:documentation>Tipo de SubDescuento</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:enumeration value="$">
+																	<xs:annotation>
+																		<xs:documentation>Descuento en Monto</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="%">
+																	<xs:annotation>
+																		<xs:documentation>Descuento en Porcentaje</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="ValorDscto" type="SiiDte:Dec16_2Type">
+														<xs:annotation>
+															<xs:documentation>Valor del SubDescuento</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="RecargoPct" type="SiiDte:PctType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Porcentaje de Recargo</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="RecargoMonto" type="SiiDte:MntImpType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Monto de Recargo</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="SubRecargo" minOccurs="0" maxOccurs="5">
+											<xs:annotation>
+												<xs:documentation>Desglose del Recargo</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="TipoRecargo">
+														<xs:annotation>
+															<xs:documentation>Tipo de SubRecargo</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:enumeration value="$">
+																	<xs:annotation>
+																		<xs:documentation>Recargo en Monto</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="%">
+																	<xs:annotation>
+																		<xs:documentation>Recargo en Porcentaje</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="ValorRecargo" type="SiiDte:Dec16_2Type">
+														<xs:annotation>
+															<xs:documentation>Valor de SubRecargo</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="MontoItem">
+											<xs:annotation>
+												<xs:documentation>Monto por Linea de Detalle. Corresponde al Monto Neto, a menos que MntBruto Indique lo Contrario </xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:decimal">
+													<xs:minInclusive value="0.0000"/>
+													<xs:maxInclusive value="99999999999999.9999"/>
+													<xs:totalDigits value="18"/>
+													<xs:fractionDigits value="4"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="SubTotInfo" minOccurs="0" maxOccurs="20">
+								<xs:annotation>
+									<xs:documentation>Subtotales Informativos</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="NroSTI">
+											<xs:annotation>
+												<xs:documentation>Número de Subtotal </xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:maxInclusive value="99"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="GlosaSTI">
+											<xs:annotation>
+												<xs:documentation>Glosa</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="40"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="OrdenSTI" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Ubicación para Impresión </xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:maxInclusive value="99"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="SubTotNetoSTI" type="SiiDte:Dec16_2Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor Neto del Subtotal</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="SubTotIVASTI" type="SiiDte:Dec16_2Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor del IVA del Subtotal</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="SubTotAdicSTI" type="SiiDte:Dec16_2Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor de los Impuestos adicionales o específicos del Subtotal</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="SubTotExeSTI" type="SiiDte:Dec16_2Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor no Afecto o Exento del Subtotal</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="ValSubtotSTI" type="SiiDte:Dec16_2Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor de la línea de subtotal</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="LineasDeta" minOccurs="0" maxOccurs="60">
+											<xs:annotation>
+												<xs:documentation>TABLA de  Líneas de Detalle que se agrupan en el Subtotal</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger"/>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="DscRcgGlobal" minOccurs="0" maxOccurs="20">
+								<xs:annotation>
+									<xs:documentation>Descuentos y/o Recargos que afectan al total del Documento</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="NroLinDR" type="xs:positiveInteger">
+											<xs:annotation>
+												<xs:documentation>Numero Secuencial de Linea</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="TpoMov">
+											<xs:annotation>
+												<xs:documentation>Tipo de Movimiento</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:enumeration value="D">
+														<xs:annotation>
+															<xs:documentation>Descuento</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="R">
+														<xs:annotation>
+															<xs:documentation>Recargo</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="GlosaDR" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Descripcion del Descuento o Recargo</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="45"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="TpoValor">
+											<xs:annotation>
+												<xs:documentation>Unidad en que se Expresa el Valor</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:enumeration value="%">
+														<xs:annotation>
+															<xs:documentation>El valor se Expresa como Porcentaje</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="$">
+														<xs:annotation>
+															<xs:documentation>El Valor se Expresa en Pesos</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="ValorDR" type="SiiDte:Dec16_2Type">
+											<xs:annotation>
+												<xs:documentation>Valor del Descuento o Recargo</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="ValorDROtrMnda" type="SiiDte:Dec14_4Type" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor en otra moneda</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="IndExeDR" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Indica si el D/R es No Afecto o No Facturable</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:enumeration value="1">
+														<xs:annotation>
+															<xs:documentation>Descuento/Recargo Global No Afecto</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="2">
+														<xs:annotation>
+															<xs:documentation>Descuento/Recargo No Facturable</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="Referencia" minOccurs="0" maxOccurs="40">
+								<xs:annotation>
+									<xs:documentation>Identificacion de otros documentos Referenciados por Documento</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="NroLinRef">
+											<xs:annotation>
+												<xs:documentation>Numero Secuencial de Linea de Referencia</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:maxInclusive value="99"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="TpoDocRef">
+											<xs:annotation>
+												<xs:documentation>Tipo de Documento de Referencia</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="3"/>
+													<xs:minLength value="1"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="IndGlobal" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Indica que se esta Referenciando un Conjunto de Documentos</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:nonNegativeInteger">
+													<xs:totalDigits value="1"/>
+													<xs:enumeration value="1">
+														<xs:annotation>
+															<xs:documentation>El Documento hace Referencia a un Conjunto de Documentos Tributarios del Mismo Tipo</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="FolioRef" type="SiiDte:FolioRType">
+											<xs:annotation>
+												<xs:documentation>Folio del Documento de Referencia</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="RUTOtr" type="SiiDte:RUTType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>RUT Otro Contribuyente</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="IdAdicOtr" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Identificador Adicional del otro contribuyente</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="20"/>
+													<xs:minLength value="1"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="FchRef">
+											<xs:annotation>
+												<xs:documentation>Fecha de la Referencia</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:date">
+													<xs:minInclusive value="1950-01-01"/>
+													<xs:maxInclusive value="2050-12-31"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="CodRef" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Tipo de Uso de la Referencia</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:enumeration value="1">
+														<xs:annotation>
+															<xs:documentation>Anula Documento de Referencia</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="2">
+														<xs:annotation>
+															<xs:documentation>Corrige Texto del Documento de Referencia</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="3">
+														<xs:annotation>
+															<xs:documentation>Corrige Montos</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="RazonRef" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Razon Explicita por la que se Referencia el Documento</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="90"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="TED">
+								<xs:annotation>
+									<xs:documentation>Timbre Electronico de DTE</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="DD">
+											<xs:annotation>
+												<xs:documentation>Datos Basicos de Documento</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="RE" type="SiiDte:RUTType">
+														<xs:annotation>
+															<xs:documentation>RUT Emisor</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TD" type="SiiDte:EXPType">
+														<xs:annotation>
+															<xs:documentation>Tipo DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="F" type="SiiDte:FolioType">
+														<xs:annotation>
+															<xs:documentation>Folio DTE</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="FE" type="SiiDte:FechaType">
+														<xs:annotation>
+															<xs:documentation>Fecha Emision DTE en Formato AAAA-MM-DD</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="RR" type="SiiDte:RUTType">
+														<xs:annotation>
+															<xs:documentation>RUT Receptor</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="RSR">
+														<xs:annotation>
+															<xs:documentation>Razon Social Receptor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="40"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="MNT">
+														<xs:annotation>
+															<xs:documentation>Monto Total DTE</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:decimal">
+																<xs:minInclusive value="0.0000"/>
+																<xs:maxInclusive value="99999999999999.9999"/>
+																<xs:totalDigits value="18"/>
+																<xs:fractionDigits value="4"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="IT1">
+														<xs:annotation>
+															<xs:documentation>Descripcion Primer Item de Detalle</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="40"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CAF">
+														<xs:annotation>
+															<xs:documentation>Codigo Autorizacion Folios</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="DA">
+																	<xs:annotation>
+																		<xs:documentation>Datos de Autorizacion de Folios</xs:documentation>
+																	</xs:annotation>
+																	<xs:complexType>
+																		<xs:sequence>
+																			<xs:element name="RE" type="SiiDte:RUTType">
+																				<xs:annotation>
+																					<xs:documentation>RUT Emisor</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																			<xs:element name="RS">
+																				<xs:annotation>
+																					<xs:documentation>Razon Social Emisor</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:string">
+																						<xs:minLength value="1"/>
+																						<xs:maxLength value="40"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="TD" type="SiiDte:EXPType">
+																				<xs:annotation>
+																					<xs:documentation>Tipo DTE</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																			<xs:element name="RNG">
+																				<xs:annotation>
+																					<xs:documentation>Rango Autorizado de Folios</xs:documentation>
+																				</xs:annotation>
+																				<xs:complexType>
+																					<xs:sequence>
+																						<xs:element name="D" type="SiiDte:FolioType">
+																							<xs:annotation>
+																								<xs:documentation>Folio Inicial (Desde)</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="H" type="SiiDte:FolioType">
+																							<xs:annotation>
+																								<xs:documentation>Folio Final (Hasta)</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																					</xs:sequence>
+																				</xs:complexType>
+																			</xs:element>
+																			<xs:element name="FA" type="SiiDte:FechaType">
+																				<xs:annotation>
+																					<xs:documentation>Fecha Autorizacion en Formato AAAA-MM-DD</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																			<xs:choice>
+																				<xs:element name="RSAPK">
+																					<xs:annotation>
+																						<xs:documentation>Clave Publica RSA del Solicitante</xs:documentation>
+																					</xs:annotation>
+																					<xs:complexType>
+																						<xs:sequence>
+																							<xs:element name="M" type="xs:base64Binary">
+																								<xs:annotation>
+																									<xs:documentation>Modulo RSA</xs:documentation>
+																								</xs:annotation>
+																							</xs:element>
+																							<xs:element name="E" type="xs:base64Binary">
+																								<xs:annotation>
+																									<xs:documentation>Exponente RSA</xs:documentation>
+																								</xs:annotation>
+																							</xs:element>
+																						</xs:sequence>
+																					</xs:complexType>
+																				</xs:element>
+																				<xs:element name="DSAPK">
+																					<xs:annotation>
+																						<xs:documentation>Clave Publica DSA del Solicitante</xs:documentation>
+																					</xs:annotation>
+																					<xs:complexType>
+																						<xs:sequence>
+																							<xs:element name="P" type="xs:base64Binary">
+																								<xs:annotation>
+																									<xs:documentation>Modulo Primo</xs:documentation>
+																								</xs:annotation>
+																							</xs:element>
+																							<xs:element name="Q" type="xs:base64Binary">
+																								<xs:annotation>
+																									<xs:documentation>Entero Divisor de P - 1</xs:documentation>
+																								</xs:annotation>
+																							</xs:element>
+																							<xs:element name="G" type="xs:base64Binary">
+																								<xs:annotation>
+																									<xs:documentation>Entero f(P, Q)</xs:documentation>
+																								</xs:annotation>
+																							</xs:element>
+																							<xs:element name="Y" type="xs:base64Binary">
+																								<xs:annotation>
+																									<xs:documentation>G**X mod P</xs:documentation>
+																								</xs:annotation>
+																							</xs:element>
+																						</xs:sequence>
+																					</xs:complexType>
+																				</xs:element>
+																			</xs:choice>
+																			<xs:element name="IDK" type="xs:long">
+																				<xs:annotation>
+																					<xs:documentation>Identificador de Llave</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																		</xs:sequence>
+																	</xs:complexType>
+																</xs:element>
+																<xs:element name="FRMA">
+																	<xs:annotation>
+																		<xs:documentation>Firma Digital (RSA) del SII Sobre DA</xs:documentation>
+																	</xs:annotation>
+																	<xs:complexType>
+																		<xs:simpleContent>
+																			<xs:extension base="xs:base64Binary">
+																				<xs:attribute name="algoritmo" type="xs:string" use="required" fixed="SHA1withRSA"/>
+																			</xs:extension>
+																		</xs:simpleContent>
+																	</xs:complexType>
+																</xs:element>
+															</xs:sequence>
+															<xs:attribute name="version" use="required" fixed="1.0"/>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="TSTED" type="SiiDte:FechaHoraType">
+														<xs:annotation>
+															<xs:documentation>TimeStamp de Generacion del Timbre</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="FRMT">
+											<xs:annotation>
+												<xs:documentation>Valor de Firma Digital  sobre DD</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:simpleContent>
+													<xs:extension base="xs:base64Binary">
+														<xs:attribute name="algoritmo" use="required">
+															<xs:simpleType>
+																<xs:restriction base="xs:string">
+																	<xs:enumeration value="SHA1withRSA"/>
+																	<xs:enumeration value="SHA1withDSA"/>
+																</xs:restriction>
+															</xs:simpleType>
+														</xs:attribute>
+													</xs:extension>
+												</xs:simpleContent>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+									<xs:attribute name="version" use="required" fixed="1.0"/>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="TmstFirma" type="SiiDte:FechaHoraType">
+								<xs:annotation>
+									<xs:documentation>Fecha y Hora en que se Firmo Digitalmente el Documento AAAA-MM-DDTHH:MI:SS</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="ID" type="xs:ID" use="required"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:choice>
+			<xs:element ref="ds:Signature">
+				<xs:annotation>
+					<xs:documentation>Firma Digital sobre Documento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="version" type="xs:decimal" use="required" fixed="1.0"/>
+	</xs:complexType>
+</xs:schema>

--- a/cl_sii/data/ref/factura_electronica/schema_dte/DTE_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schema_dte/DTE_v10.xsd
@@ -193,6 +193,18 @@ Descuento Recargo Global : se incorporar restricción en Tipo de Movimiento
 															</xs:restriction>
 														</xs:simpleType>
 													</xs:element>
+													<xs:element name="TpoTranCompra" type="SiiDte:TipoTransCOMPRA" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Tipo de Transacción para el comprador</xs:documentation>
+															<xs:documentation>Indica el Uso de Montos Brutos en Detalle</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TpoTranVenta" type="SiiDte:TipoTransVENTA" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Tipo de Transacción para el vendedor</xs:documentation>
+															<xs:documentation>Indica el Uso de Montos Brutos en Detalle</xs:documentation>
+														</xs:annotation>
+													</xs:element>
 													<xs:element name="FmaPago" minOccurs="0">
 														<xs:annotation>
 															<xs:documentation>Forma de Pago del DTE</xs:documentation>
@@ -1868,6 +1880,7 @@ según tabla Países aduana</xs:documentation>
 											<xs:simpleType>
 												<xs:restriction base="xs:string">
 													<xs:maxLength value="60"/>
+													<xs:minLength value="1"/>
 												</xs:restriction>
 											</xs:simpleType>
 										</xs:element>
@@ -2199,6 +2212,18 @@ según tabla Países aduana</xs:documentation>
 																</xs:enumeration>
 															</xs:restriction>
 														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TpoTranCompra" type="SiiDte:TipoTransCOMPRA" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Tipo de Transacción para el comprador</xs:documentation>
+															<xs:documentation>Indica el Uso de Montos Brutos en Detalle</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TpoTranVenta" type="SiiDte:TipoTransVENTA" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Tipo de Transacción para el vendedor</xs:documentation>
+															<xs:documentation>Indica el Uso de Montos Brutos en Detalle</xs:documentation>
+														</xs:annotation>
 													</xs:element>
 													<xs:element name="FmaPago" minOccurs="0">
 														<xs:annotation>
@@ -2609,7 +2634,7 @@ según tabla Países aduana</xs:documentation>
 																		<xs:documentation>Tasa de Impuesto o Retencion</xs:documentation>
 																	</xs:annotation>
 																</xs:element>
-																<xs:element name="MontoImp" type="SiiDte:MntImpType">
+																<xs:element name="MontoImp" type="SiiDte:ValorType">
 																	<xs:annotation>
 																		<xs:documentation>Monto del Impuesto o Retencion</xs:documentation>
 																	</xs:annotation>
@@ -3142,7 +3167,7 @@ según tabla Países aduana</xs:documentation>
 															</xs:restriction>
 														</xs:simpleType>
 													</xs:element>
-													<xs:element name="MNT" type="xs:unsignedLong">
+													<xs:element name="MNT" type="SiiDte:ValorType">
 														<xs:annotation>
 															<xs:documentation>Monto Total DTE</xs:documentation>
 														</xs:annotation>
@@ -4272,12 +4297,12 @@ según tabla Países aduana</xs:documentation>
 															<xs:documentation>Tipo de Cambio fijado por el Banco Central de Chile</xs:documentation>
 														</xs:annotation>
 													</xs:element>
-													<xs:element name="MntExeOtrMnda" type="SiiDte:Dec14_4Type" minOccurs="0">
+													<xs:element name="MntExeOtrMnda" type="xs:decimal" minOccurs="0">
 														<xs:annotation>
 															<xs:documentation>Monto Exento del DTE en Otra Moneda  </xs:documentation>
 														</xs:annotation>
 													</xs:element>
-													<xs:element name="MntTotOtrMnda" type="SiiDte:Dec14_4Type">
+													<xs:element name="MntTotOtrMnda" type="xs:decimal">
 														<xs:annotation>
 															<xs:documentation>Monto Total Otra Moneda</xs:documentation>
 														</xs:annotation>

--- a/cl_sii/data/ref/factura_electronica/schema_dte/EnvioDTE_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schema_dte/EnvioDTE_v10.xsd
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- El presente documento define el esquema XML que debe ser utilizado
+para realizar los envios de Documentos Tributarios Electronicos (DTE)
+hacia el Servicio de Impuestos Internos.
+
+Fecha Actualizacion:  25/05/07 15:00
+
+Se incorporan dos nuevos Tipos de datos :
+FechaType		:  Fecha entre 2000-01-01 y 2050-12-31
+FechaHoraType :  FechaType + hora entre 00:00 y 23:59
+ -->
+<xs:schema targetNamespace="http://www.sii.cl/SiiDte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:SiiDte="http://www.sii.cl/SiiDte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="DTE_v10.xsd"/>
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsignature_v10.xsd"/>
+	<xs:element name="EnvioDTE">
+		<xs:annotation>
+			<xs:documentation>Envio de Documentos Tributarios Electronicos</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="SetDTE">
+					<xs:annotation>
+						<xs:documentation>Conjunto de DTE enviados</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="Caratula">
+								<xs:annotation>
+									<xs:documentation>Resumen de Informacion Enviada</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="RutEmisor">
+											<xs:annotation>
+												<xs:documentation>RUT Emisor de los DTE</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="SiiDte:RUTType"/>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="RutEnvia" type="SiiDte:RUTType">
+											<xs:annotation>
+												<xs:documentation>RUT que envia los DTE</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="RutReceptor" type="SiiDte:RUTType">
+											<xs:annotation>
+												<xs:documentation>RUT al que se le envian los DTE</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="FchResol" type="SiiDte:FechaType">
+											<xs:annotation>
+												<xs:documentation>Fecha de Resolucion que Autoriza el Envio de DTE (AAAA-MM-DD)</xs:documentation>
+												<xs:documentation>Fecha de Resolucion que Autoriza el Envio de DTE (AAAA-MM-DD)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="NroResol" type="SiiDte:NroResolType">
+											<xs:annotation>
+												<xs:documentation>Numero de Resolucion que Autoriza el Envio de DTE</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="TmstFirmaEnv" type="SiiDte:FechaHoraType">
+											<xs:annotation>
+												<xs:documentation>Fecha y Hora de la Firma del Archivo de Envio</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="SubTotDTE" maxOccurs="20">
+											<xs:annotation>
+												<xs:documentation>Subtotales de DTE enviados</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="TpoDTE" type="SiiDte:DOCType">
+														<xs:annotation>
+															<xs:documentation>Tipo de DTE Enviado</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="NroDTE" type="xs:positiveInteger">
+														<xs:annotation>
+															<xs:documentation>Numero de DTE Enviados</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+									<xs:attribute name="version" type="xs:decimal" use="required" fixed="1.0"/>
+								</xs:complexType>
+							</xs:element>
+							<xs:element ref="SiiDte:DTE" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>Documento Tributario Electronico</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="ID" type="xs:ID" use="required"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ds:Signature">
+					<xs:annotation>
+						<xs:documentation>Firma Digital sobre SetDTE</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="version" type="xs:decimal" use="required" fixed="1.0"/>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/cl_sii/data/ref/factura_electronica/schema_dte/EnvioDTE_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schema_dte/EnvioDTE_v10.xsd
@@ -3,13 +3,15 @@
 para realizar los envios de Documentos Tributarios Electronicos (DTE)
 hacia el Servicio de Impuestos Internos.
 
-Fecha Actualizacion:  25/05/07 15:00
+Fecha Actualizacion:  30/07/10 15:00
 
 Se incorporan dos nuevos Tipos de datos :
 FechaType		:  Fecha entre 2000-01-01 y 2050-12-31
 FechaHoraType :  FechaType + hora entre 00:00 y 23:59
+
+Se limita a 2.000 documentos el máximo por envio o sobre (de acuerdo a publicación)
  -->
-<xs:schema targetNamespace="http://www.sii.cl/SiiDte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:SiiDte="http://www.sii.cl/SiiDte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema targetNamespace="http://www.sii.cl/SiiDte" xmlns:SiiDte="http://www.sii.cl/SiiDte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="DTE_v10.xsd"/>
 	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsignature_v10.xsd"/>
 	<xs:element name="EnvioDTE">
@@ -87,7 +89,7 @@ FechaHoraType :  FechaType + hora entre 00:00 y 23:59
 									<xs:attribute name="version" type="xs:decimal" use="required" fixed="1.0"/>
 								</xs:complexType>
 							</xs:element>
-							<xs:element ref="SiiDte:DTE" maxOccurs="unbounded">
+							<xs:element ref="SiiDte:DTE" maxOccurs="2000">
 								<xs:annotation>
 									<xs:documentation>Documento Tributario Electronico</xs:documentation>
 								</xs:annotation>

--- a/cl_sii/data/ref/factura_electronica/schema_dte/README.md
+++ b/cl_sii/data/ref/factura_electronica/schema_dte/README.md
@@ -1,0 +1,98 @@
+# schema_dte
+
+This directory contains all the files of `schema_dte.zip`, plus this text file.
+All the files have been preserved as they were; schemas are in their original text encoding
+(ISO-8859-1) and have not been modified in the slightest way.
+
+The most significant structures are:
+- XML element `EnvioDTE`: "Envio de Documentos Tributarios Electronicos".
+- XML data type `DTEDefType`: "Documento Tributario Electronico".
+
+Note: DTE means "Documento Tributario Electrónico".
+
+
+## Source
+
+[schema_dte.zip](http://www.sii.cl/factura_electronica/schema_dte.zip) (2018-11-28),
+referenced from official webpage
+[SII](http://www.sii.cl)
+/ [Factura electrónica](http://www.sii.cl/servicios_online/1039-.html)
+/ [FORMATO XML DE DOCUMENTOS ELECTRÓNICOS](http://www.sii.cl/factura_electronica/formato_xml.htm)
+as
+"[Bajar schema XML de Documentos Tributarios Electrónicos](http://www.sii.cl/factura_electronica/schema_dte.zip) (Incluye Documentos de exportación)"
+
+
+## Contents
+
+
+### Detail
+
+- `DTE_v10.xsd`: "XSD principal y que incluye a los 3" otros XSD.
+  - XML target namespace: `http://www.sii.cl/SiiDte`.
+  - XML included/imported schemas: `SiiTypes_v10.xsd`, `xmldsignature_v10.xsd`.
+  - XML elements:
+    - `DTE`: (no description nor annotations)
+  - XML data types:
+    - `DTEDefType`: "Documento Tributario Electronico".
+
+- `EnvioDTE_v10.xsd`: "descripción de documentos"
+  - XML target namespace: `http://www.sii.cl/SiiDte`.
+  - XML included/imported schemas: `DTE_v10.xsd`, `xmldsignature_v10.xsd`.
+  - XML elements:
+    - `EnvioDTE`: "Envio de Documentos Tributarios Electronicos".
+  - XML data types: none.
+
+- `SiiTypes_v10.xsd`: "descripción de tipos de datos"
+  - XML target namespace: `http://www.sii.cl/SiiDte`.
+  - XML included/imported schemas: none.
+  - XML elements: none.
+  - XML data types:
+    - `DOCType`: "Todos los tipos de Documentos Tributarios Electronicos".
+    - `DocType`: "Tipos de Documento".
+    - `DTEType`: "Tipos de Documentos Tributarios Electronicos".
+    - `DTEFacturasType`: "Tipos de Documentos Tributarios Electronicos" (same description as
+      `DTEType` but different elements).
+    - `LIQType`: "Tipos de Liquidaciones".
+    - `EXPType`: "Tipos de Facturas de  Exportacion".
+    - `RUTType`: "Rol Unico Tributario (99..99-X)".
+    - `MedioPagoType`: "Medios de Pago".
+    - `TipMonType`: "Tipos de Moneda de Aduana".
+    - `MontoType`: "Monto de 18 digitos".
+    - `MntImpType`: "Monto de Impuesto - 18 digitos".
+    - `ValorType`: "Monto de 18 digitos - Positivo o Negativo".
+    - `FolioType`: "Folio de DTE - 10 digitos".
+    - `FolioRType`: "Folio de Referencia - 18 digitos (incluye el cero)".
+    - `ImpAdicType`: "Tipo de Impuesto o Retencion Adicional".
+    - `ImpAdicDTEType`: "Tipo de Impuesto o Retencion Adicional de los DTE".
+    - `MailType`: "Dirección email".
+    - `DineroPorcentajeType`: "Unidad en que se expresa el Valor".
+    - `NroResolType`: "Número de Resolución".
+    - `RznSocLargaType`: "Razón Social (max 100)".
+    - `RznSocCortaType`: "Razón Social (max 40)".
+    - `DireccSoloDTEType`: "Dirección (maz 60)" (sic).
+    - `DireccType`: "Dirección (max 80)".
+    - `ComunaType`: "Comuna".
+    - `CiudadType`: "Ciudad".
+    - `FonoType`: "Fono".
+    - `NombreType`: "Nombre".
+    - `FechaType`: "Fecha entre 2000-01-01 y 2050-12-31".
+    - `FechaHoraType`: "FechaType + hora entre 00:00 y 23:59;".
+    - `Dec16_2Type`: "Monto con 16 Digitos de Cuerpo y 2 Decimales".
+    - `Dec14_4Type`: "Monto con 14 Digitos de Cuerpo y 4 Decimales".
+    - `Dec8_4Type`: "Monto con 8 Digitos de Cuerpo y 4 Decimales".
+    - `Dec6_4Type`: "Monto con 6 Digitos de Cuerpo y 4 Decimales".
+    - `Dec12_6Type`: "Monto con 12 Digitos de Cuerpo y 6 Decimales".
+    - `PctType`: "Monto de Porcentaje ( 3 y 2)".
+
+
+### Notes
+
+- Enums `DOCType`, `DocType`, `DTEType` and `DTEFacturasType` (all of them in `SiiTypes_v10.xsd`)
+  are **very** similar.
+- Enums `DocType` and `DTEType` have exactly the same elements (although descriptions differ).
+- The elements of the following enums are strictly subgroups of enum `DOCType`:
+  - `DocType` and `DTEType`: same elements.
+  - `DTEFacturasType`
+  - `LIQType`: "Tipos de Liquidaciones".
+  - `EXPType`: "Tipos de Facturas de  Exportacion".
+- File `xmldsignature_v10.xsd` is identical to `../schema_iecv/xmldsignature_v10.xsd`.

--- a/cl_sii/data/ref/factura_electronica/schema_dte/README.md
+++ b/cl_sii/data/ref/factura_electronica/schema_dte/README.md
@@ -13,6 +13,9 @@ Note: DTE means "Documento Tributario Electrónico".
 
 ## Source
 
+
+### Original & Official
+
 [schema_dte.zip](http://www.sii.cl/factura_electronica/schema_dte.zip) (2018-11-28),
 referenced from official webpage
 [SII](http://www.sii.cl)
@@ -20,6 +23,14 @@ referenced from official webpage
 / [FORMATO XML DE DOCUMENTOS ELECTRÓNICOS](http://www.sii.cl/factura_electronica/formato_xml.htm)
 as
 "[Bajar schema XML de Documentos Tributarios Electrónicos](http://www.sii.cl/factura_electronica/schema_dte.zip) (Incluye Documentos de exportación)"
+
+
+### Updates
+
+Unfortunately the files available on SII's website are outdated with respect to the regulations
+(and even with respect to the documentation PDFs published alongside).
+
+Schema files will be updated as necessary, indicating the source in the corresponding commit.
 
 
 ## Contents

--- a/cl_sii/data/ref/factura_electronica/schema_dte/SiiTypes_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schema_dte/SiiTypes_v10.xsd
@@ -1,0 +1,811 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--Esquema para tipos de datos generales.
+Fecha Actualizacion:  25/05/07 15:00
+
+Se incorporan dos nuevos Tipos de datos :
+FechaType		:  Fecha entre 2000-01-01 y 2050-12-31
+FechaHoraType :  FechaType + hora entre 00:00 y 23:59
+ImpAdicDTEType: elimina codigo 29 para DTE
+
+Fecha Actualizacion:  30/05/2011 12:00
+
+Se incorpora restricción en DineroPorcentajeType para que sea dato de largo 1
+
+-->
+<xs:schema targetNamespace="http://www.sii.cl/SiiDte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ns1="http://www.sii.cl/SiiDte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:simpleType name="DOCType">
+		<xs:annotation>
+			<xs:documentation>Todos los tipos de Documentos Tributarios Electronicos</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:positiveInteger">
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>Factura Electronica</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>Factura Electronica de Venta de Bienes y Servicios No afectos o Exento de IVA</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="43"/>
+			<xs:enumeration value="46">
+				<xs:annotation>
+					<xs:documentation>Factura de Compra Electronica</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="52">
+				<xs:annotation>
+					<xs:documentation>Guia de Despacho Electronica</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="56">
+				<xs:annotation>
+					<xs:documentation>Nota de Debito Electronica</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="61">
+				<xs:annotation>
+					<xs:documentation>Nota de Credito Electronica</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="110"/>
+			<xs:enumeration value="111"/>
+			<xs:enumeration value="112"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DTEType">
+		<xs:annotation>
+			<xs:documentation>Tipos de Documentos Tributarios Electronicos</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:positiveInteger">
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>Factura Electronica</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>Factura Electronica de Venta de Bienes y Servicios No afectos o Exento de IVA</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="46">
+				<xs:annotation>
+					<xs:documentation>Factura de Compra Electronica</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="52">
+				<xs:annotation>
+					<xs:documentation>Guia de Despacho Electronica</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="56">
+				<xs:annotation>
+					<xs:documentation>Nota de Debito Electronica</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="61">
+				<xs:annotation>
+					<xs:documentation>Nota de Credito Electronica</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DTEFacturasType">
+		<xs:annotation>
+			<xs:documentation>Tipos de Documentos Tributarios Electronicos</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:positiveInteger">
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>Factura Electronica</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>Factura Electronica de Venta de Bienes y Servicios No afectos o Exento de IVA</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="46">
+				<xs:annotation>
+					<xs:documentation>Factura de Compra Electronica</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="43">
+				<xs:annotation>
+					<xs:documentation>Liquidacion actura Electronica</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RUTType">
+		<xs:annotation>
+			<xs:documentation>Rol Unico Tributario (99..99-X)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="10"/>
+			<xs:minLength value="3"/>
+			<xs:pattern value="[0-9]+-([0-9]|K)"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MntImpType">
+		<xs:annotation>
+			<xs:documentation>Monto de Impuesto - 18 digitos</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:positiveInteger">
+			<xs:totalDigits value="18"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ValorType">
+		<xs:annotation>
+			<xs:documentation>Monto de 18 digitos - Positivo o Negativo</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:integer">
+			<xs:totalDigits value="18"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FolioType">
+		<xs:annotation>
+			<xs:documentation>Folio de DTE - 10 digitos</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:positiveInteger">
+			<xs:totalDigits value="10"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FolioRType">
+		<xs:annotation>
+			<xs:documentation>Folio de Referencia - 18 digitos (incluye el cero)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="18"/>
+			<xs:minLength value="1"/>
+		</xs:restriction>
+		<!-- Referencia a Documentos con Folio alfanumericos
+		<xs:restriction base="xs:nonNegativeInteger">
+			<xs:totalDigits value="10"/>
+		</xs:restriction>
+-->
+	</xs:simpleType>
+	<xs:simpleType name="Dec16_2Type">
+		<xs:annotation>
+			<xs:documentation>Monto con 16 Digitos de Cuerpo y 2 Decimales </xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="18"/>
+			<xs:fractionDigits value="2"/>
+			<xs:minInclusive value="0.01"/>
+			<xs:maxInclusive value="9999999999999999.99"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Dec14_4Type">
+		<xs:annotation>
+			<xs:documentation>Monto con 14 Digitos de Cuerpo y 4 Decimales</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="18"/>
+			<xs:fractionDigits value="4"/>
+			<xs:minInclusive value="0.0001"/>
+			<xs:maxInclusive value="99999999999999.9999"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Dec8_4Type">
+		<xs:annotation>
+			<xs:documentation>Monto con 8 Digitos de Cuerpo y 4 Decimales</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="12"/>
+			<xs:fractionDigits value="4"/>
+			<xs:minInclusive value="0.0001"/>
+			<xs:maxInclusive value="99999999.9999"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Dec6_4Type">
+		<xs:annotation>
+			<xs:documentation>Monto con 6 Digitos de Cuerpo y 4 Decimales</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="10"/>
+			<xs:fractionDigits value="4"/>
+			<xs:minInclusive value="0.0001"/>
+			<xs:maxInclusive value="999999.9999"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PctType">
+		<xs:annotation>
+			<xs:documentation>Monto de Porcentaje ( 3 y 2)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="5"/>
+			<xs:fractionDigits value="2"/>
+			<xs:minInclusive value="0.01"/>
+			<xs:maxInclusive value="999.99"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Dec12_6Type">
+		<xs:annotation>
+			<xs:documentation>Monto con 12 Digitos de Cuerpo y 6 Decimales</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="18"/>
+			<xs:fractionDigits value="6"/>
+			<xs:minInclusive value="0.000001"/>
+			<xs:maxInclusive value="999999999999.999999"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ImpAdicType">
+		<xs:annotation>
+			<xs:documentation>Tipo de Impuesto o Retencion Adicional</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="3"/>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>IVA Margen Comercializacion (Factura Venta del Contribuyente) [F29 - C039]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Total (Factura Compra del Contribuyente) [F29 - C039]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Parcial (Factura Compra del Contribuyente) [F29]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>IVA Anticipado Faenamiento Carne [F29 - C042]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>IVA Anticipado Carne [F29 - C042]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>IVA Anticipado Harina [F29 - C042]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Impuesto Adicional Productos Art. 37 a) b) c)  Oro, Joyas, Pieles [F29 - C113]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 42 a) Licores, Pisco, Destilados [F29 - C148]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 42 c) Vinos</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 42 c) Cervezas y Bebidas Alcoholicas [F29 - C150]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 42 d) y e) Bebidas Analcoholicas y Minerales [F29 - C146]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Impuesto Especifico Diesel [F29 - C127]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>Recuperación Impuesto Específico diesel Transportistas  Para transportistas de carga
+ Art 2° Ley N°19.764/2001</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Legumbres</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Silvestres</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Ganado</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Madera</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Trigo</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>Impuesto Especifico Gasolina</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="36">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Arroz</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="37">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Hidrobiologicas</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="38">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Chatarra</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="39">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido PPA</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Opcional</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Construccion</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="44">
+				<xs:annotation>
+					<xs:documentation>Impuesto Adicional Productos Art. 37 e) h) i) l)  1ra Venta (Alfombras, C. Rodantes, Caviar, Armas) [F29 - C113]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="45">
+				<xs:annotation>
+					<xs:documentation>Impuesto Adicional Productos Art. 37 j)  1ra Venta (Pirotecnia) [F29 - C113]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="46"/>
+			<xs:enumeration value="47"/>
+			<xs:enumeration value="48"/>
+			<xs:enumeration value="49"/>
+			<xs:enumeration value="50"/>
+			<xs:enumeration value="51"/>
+			<xs:enumeration value="52"/>
+			<xs:enumeration value="53"/>
+			<xs:enumeration value="301"/>
+			<xs:enumeration value="321"/>
+			<xs:enumeration value="331"/>
+			<xs:enumeration value="341"/>
+			<xs:enumeration value="361"/>
+			<xs:enumeration value="371"/>
+			<xs:enumeration value="481"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ImpAdicDTEType">
+		<xs:annotation>
+			<xs:documentation>Tipo de Impuesto o Retencion Adicional de los DTE</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="3"/>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>IVA Margen Comercializacion (Factura Venta del Contribuyente) [F29 - C039]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Total (Factura Compra del Contribuyente) [F29 - C039]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Parcial (Factura Compra del Contribuyente) [F29]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>IVA Anticipado Faenamiento Carne [F29 - C042]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>IVA Anticipado Carne [F29 - C042]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>IVA Anticipado Harina [F29 - C042]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Impuesto Adicional Productos Art. 37 a) b) c)  Oro, Joyas, Pieles [F29 - C113]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 42 a) Licores, Pisco, Destilados [F29 - C148]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 42 c) Vinos</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 42 c) Cervezas y Bebidas Alcoholicas [F29 - C150]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 42 d) y e) Bebidas Analcoholicas y Minerales [F29 - C146]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Impuesto Especifico Diesel [F29 - C127]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Legumbres</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Silvestres</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Ganado</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Madera</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Trigo</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>Impuesto Especifico Gasolina</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="36">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Arroz</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="37">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Hidrobiologicas</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="38">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Chatarra</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="39">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido PPA</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Opcional</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Construccion</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="44">
+				<xs:annotation>
+					<xs:documentation>Impuesto Adicional Productos Art. 37 e) h) i) l)  1ra Venta (Alfombras, C. Rodantes, Caviar, Armas) [F29 - C113]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="45">
+				<xs:annotation>
+					<xs:documentation>Impuesto Adicional Productos Art. 37 j)  1ra Venta (Pirotecnia) [F29 - C113]</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="46"/>
+			<xs:enumeration value="47"/>
+			<xs:enumeration value="48"/>
+			<xs:enumeration value="49"/>
+			<xs:enumeration value="50"/>
+			<xs:enumeration value="51"/>
+			<xs:enumeration value="52"/>
+			<xs:enumeration value="53"/>
+			<xs:enumeration value="301"/>
+			<xs:enumeration value="321"/>
+			<xs:enumeration value="331"/>
+			<xs:enumeration value="341"/>
+			<xs:enumeration value="361"/>
+			<xs:enumeration value="371"/>
+			<xs:enumeration value="481"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MontoType">
+		<xs:annotation>
+			<xs:documentation>Monto de 18 digitos</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:nonNegativeInteger">
+			<xs:totalDigits value="18"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DocType">
+		<xs:annotation>
+			<xs:documentation>Tipos de Documento</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:positiveInteger">
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>Factura Electronica</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>Factura Electronica No Afecta o Exenta</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="46">
+				<xs:annotation>
+					<xs:documentation>Factura de Compra Electronica</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="52">
+				<xs:annotation>
+					<xs:documentation>Guia de Despacho Electronica</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="56"/>
+			<xs:enumeration value="61"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MailType">
+		<xs:annotation>
+			<xs:documentation>Dirección email</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="80"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DineroPorcentajeType">
+		<xs:annotation>
+			<xs:documentation>Unidad en que se expresa el Valor</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="1"/>
+			<xs:enumeration value="%">
+				<xs:annotation>
+					<xs:documentation>El valor se Expresa como Porcentaje</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="$">
+				<xs:annotation>
+					<xs:documentation>El Valor se Expresa en Pesos</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="NroResolType">
+		<xs:annotation>
+			<xs:documentation>Número de Resolución</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:nonNegativeInteger">
+			<xs:totalDigits value="6"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RznSocLargaType">
+		<xs:annotation>
+			<xs:documentation>Razón Social (max 100)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="100"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="RznSocCortaType">
+		<xs:annotation>
+			<xs:documentation>Razón Social (max 40)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="40"/>
+			<xs:minLength value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DireccSoloDTEType">
+		<xs:annotation>
+			<xs:documentation>Dirección (maz 60)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="60"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DireccType">
+		<xs:annotation>
+			<xs:documentation>Dirección (max 80)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="80"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ComunaType">
+		<xs:annotation>
+			<xs:documentation>Comuna</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="20"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="CiudadType">
+		<xs:annotation>
+			<xs:documentation>Ciudad</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="20"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FonoType">
+		<xs:annotation>
+			<xs:documentation>Fono</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="40"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="NombreType">
+		<xs:annotation>
+			<xs:documentation>Nombre</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="40"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="LIQType">
+		<xs:annotation>
+			<xs:documentation>Tipos de Liquidaciones </xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:positiveInteger">
+			<xs:enumeration value="43"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="EXPType">
+		<xs:annotation>
+			<xs:documentation>Tipos de Facturas de  Exportacion</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:positiveInteger">
+			<xs:enumeration value="110"/>
+			<xs:enumeration value="111"/>
+			<xs:enumeration value="112"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MedioPagoType">
+		<xs:annotation>
+			<xs:documentation>Medios de Pago</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CH">
+				<xs:annotation>
+					<xs:documentation>Cheque</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LT">
+				<xs:annotation>
+					<xs:documentation>Letra</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EF">
+				<xs:annotation>
+					<xs:documentation>Efectivo</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PE">
+				<xs:annotation>
+					<xs:documentation>Pago a Cuenta Corriente</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TC">
+				<xs:annotation>
+					<xs:documentation>Tarjeta de Credito</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CF">
+				<xs:annotation>
+					<xs:documentation>Cheque a Fecha</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OT">
+				<xs:annotation>
+					<xs:documentation>Otro</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:attribute name="version" type="xs:decimal" fixed="1.0"/>
+	<xs:simpleType name="TipMonType">
+		<xs:annotation>
+			<xs:documentation>Tipos de Moneda de Aduana</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="15"/>
+			<xs:enumeration value="BOLIVAR"/>
+			<xs:enumeration value="BOLIVIANO"/>
+			<xs:enumeration value="CHELIN"/>
+			<xs:enumeration value="CORONA DIN"/>
+			<xs:enumeration value="CORONA NOR"/>
+			<xs:enumeration value="CORONA SC"/>
+			<xs:enumeration value="CRUZEIRO REAL"/>
+			<xs:enumeration value="DIRHAM"/>
+			<xs:enumeration value="DOLAR AUST"/>
+			<xs:enumeration value="DOLAR CAN"/>
+			<xs:enumeration value="DOLAR HK"/>
+			<xs:enumeration value="DOLAR NZ"/>
+			<xs:enumeration value="DOLAR SIN"/>
+			<xs:enumeration value="DOLAR TAI"/>
+			<xs:enumeration value="DOLAR USA"/>
+			<xs:enumeration value="DRACMA"/>
+			<xs:enumeration value="ESCUDO"/>
+			<xs:enumeration value="EURO"/>
+			<xs:enumeration value="FLORIN"/>
+			<xs:enumeration value="FRANCO BEL"/>
+			<xs:enumeration value="FRANCO FR"/>
+			<xs:enumeration value="FRANCO SZ"/>
+			<xs:enumeration value="GUARANI"/>
+			<xs:enumeration value="LIBRA EST"/>
+			<xs:enumeration value="LIRA"/>
+			<xs:enumeration value="MARCO AL"/>
+			<xs:enumeration value="MARCO FIN"/>
+			<xs:enumeration value="NUEVO SOL"/>
+			<xs:enumeration value="OTRAS MONEDAS"/>
+			<xs:enumeration value="PESETA"/>
+			<xs:enumeration value="PESO"/>
+			<xs:enumeration value="PESO CL"/>
+			<xs:enumeration value="PESO COL"/>
+			<xs:enumeration value="PESO MEX"/>
+			<xs:enumeration value="PESO URUG"/>
+			<xs:enumeration value="RAND"/>
+			<xs:enumeration value="RENMINBI"/>
+			<xs:enumeration value="RUPIA"/>
+			<xs:enumeration value="SUCRE"/>
+			<xs:enumeration value="YEN"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FechaType">
+		<xs:annotation>
+			<xs:documentation> Fecha entre 2000-01-01 y 2050-12-31</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:date">
+			<xs:minInclusive value="2000-01-01"/>
+			<xs:maxInclusive value="2050-12-31"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FechaHoraType" final="restriction">
+		<xs:annotation>
+			<xs:documentation> FechaType + hora entre 00:00 y 23:59;  </xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:dateTime">
+			<xs:minInclusive value="2000-01-01T00:00:00" fixed="true"/>
+			<xs:maxInclusive value="2050-12-31T23:59:59"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/cl_sii/data/ref/factura_electronica/schema_dte/SiiTypes_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schema_dte/SiiTypes_v10.xsd
@@ -8,8 +8,14 @@ FechaHoraType :  FechaType + hora entre 00:00 y 23:59
 ImpAdicDTEType: elimina codigo 29 para DTE
 
 Fecha Actualizacion:  30/05/2011 12:00
-
 Se incorpora restricción en DineroPorcentajeType para que sea dato de largo 1
+
+Fecha Actualizacion:  07/05/2014 11:30
+ImpAdicDTEType	: se agregan los codigos 54 y 55 (SDI-1092)
+
+Fecha Actualizacion:  30/09/2014 11:40
+ImpAdicDTEType	: se agregan el codigo de impuesto 271 (SDI-9342)
+
 
 -->
 <xs:schema targetNamespace="http://www.sii.cl/SiiDte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ns1="http://www.sii.cl/SiiDte" elementFormDefault="qualified" attributeFormDefault="unqualified">
@@ -382,6 +388,9 @@ Se incorpora restricción en DineroPorcentajeType para que sea dato de largo 1
 			<xs:enumeration value="51"/>
 			<xs:enumeration value="52"/>
 			<xs:enumeration value="53"/>
+			<xs:enumeration value="54"/>
+			<xs:enumeration value="55"/>
+			<xs:enumeration value="271"/>
 			<xs:enumeration value="301"/>
 			<xs:enumeration value="321"/>
 			<xs:enumeration value="331"/>
@@ -535,6 +544,13 @@ Se incorpora restricción en DineroPorcentajeType para que sea dato de largo 1
 			<xs:enumeration value="51"/>
 			<xs:enumeration value="52"/>
 			<xs:enumeration value="53"/>
+			<xs:enumeration value="54"/>
+			<xs:enumeration value="55"/>
+			<xs:enumeration value="271">
+				<xs:annotation>
+					<xs:documentation>Bebidas analcohólicas y Minerales con elevado contenido de azúcares.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="301"/>
 			<xs:enumeration value="321"/>
 			<xs:enumeration value="331"/>
@@ -806,6 +822,67 @@ Se incorpora restricción en DineroPorcentajeType para que sea dato de largo 1
 		<xs:restriction base="xs:dateTime">
 			<xs:minInclusive value="2000-01-01T00:00:00" fixed="true"/>
 			<xs:maxInclusive value="2050-12-31T23:59:59"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TipoTransCOMPRA">
+		<xs:annotation>
+			<xs:documentation>Tipo de Transacción para el comprador</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:nonNegativeInteger">
+			<xs:enumeration value="1">
+				<xs:annotation>
+					<xs:documentation>Del Giro</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="2">
+				<xs:annotation>
+					<xs:documentation>Supermercados y Similares</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="3">
+				<xs:annotation>
+					<xs:documentation>Adquisición o Construcción de Bienes inmuebles, BBRR</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="4">
+				<xs:annotation>
+					<xs:documentation>Activo Fijo</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="5">
+				<xs:annotation>
+					<xs:documentation>Compra IVA Uso Común o no Recuperable</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="6"/>
+			<xs:enumeration value="7"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TipoTransVENTA">
+		<xs:annotation>
+			<xs:documentation>Tipo de Transacción para el vendedor</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:positiveInteger">
+			<xs:enumeration value="1">
+				<xs:annotation>
+					<xs:documentation>Del Giro</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="2">
+				<xs:annotation>
+					<xs:documentation>Ventas que no son del Giro (Activo Fijo y Otros)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="3">
+				<xs:annotation>
+					<xs:documentation>Venta de Bienes inmuebles, BBRR</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="4">
+				<xs:annotation>
+					<xs:documentation>NCE MR * (solo NCE</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
 </xs:schema>

--- a/cl_sii/data/ref/factura_electronica/schema_dte/xmldsignature_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schema_dte/xmldsignature_v10.xsd
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- Schema for XML Signatures
+    http://www.w3.org/2000/09/xmldsig#
+    $Revision: 1.1 $ on $Date: 2002/02/08 20:32:26 $ by $Author: reagle $
+
+    Copyright 2001 The Internet Society and W3C (Massachusetts Institute
+    of Technology, Institut National de Recherche en Informatique et en
+    Automatique, Keio University). All Rights Reserved.
+    http://www.w3.org/Consortium/Legal/
+
+    This document is governed by the W3C Software License [1] as described
+    in the FAQ [2].
+
+    [1] http://www.w3.org/Consortium/Legal/copyright-software-19980720
+    [2] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD 
+
+Fecha ultima actualización : 10-03-05
+
+-->
+<ds:schema targetNamespace="http://www.w3.org/2000/09/xmldsig#" xmlns:xmldsig="http://www.w3.org/2000/09/xmldsig#" xmlns:ds="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<ds:element name="Signature" type="xmldsig:SignatureType">
+		<ds:annotation>
+			<ds:documentation>Firma Digital sobre Documento</ds:documentation>
+		</ds:annotation>
+	</ds:element>
+	<ds:complexType name="SignatureType">
+		<ds:annotation>
+			<ds:documentation>Firma Digital con Restricciones</ds:documentation>
+		</ds:annotation>
+		<ds:sequence>
+			<ds:element name="SignedInfo">
+				<ds:annotation>
+					<ds:documentation>Descripcion de la Informacion Firmada y del Metodo de Firma</ds:documentation>
+				</ds:annotation>
+				<ds:complexType>
+					<ds:sequence>
+						<ds:element name="CanonicalizationMethod">
+							<ds:annotation>
+								<ds:documentation>Algoritmo de Canonicalizacion</ds:documentation>
+							</ds:annotation>
+							<ds:complexType>
+								<ds:attribute name="Algorithm" type="ds:anyURI" use="required" fixed="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+							</ds:complexType>
+						</ds:element>
+						<ds:element name="SignatureMethod">
+							<ds:annotation>
+								<ds:documentation>Algoritmo de Firma</ds:documentation>
+							</ds:annotation>
+							<ds:complexType>
+								<ds:attribute name="Algorithm" use="required">
+									<ds:simpleType>
+										<ds:restriction base="ds:anyURI">
+											<ds:enumeration value="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+											<ds:enumeration value="http://www.w3.org/2000/09/xmldsig#dsa-sha1"/>
+										</ds:restriction>
+									</ds:simpleType>
+								</ds:attribute>
+							</ds:complexType>
+						</ds:element>
+						<ds:element name="Reference">
+							<ds:annotation>
+								<ds:documentation>Referencia a Elemento Firmado</ds:documentation>
+							</ds:annotation>
+							<ds:complexType>
+								<ds:sequence>
+									<ds:element name="Transforms" minOccurs="0">
+										<ds:annotation>
+											<ds:documentation>Algoritmo de Transformacion</ds:documentation>
+										</ds:annotation>
+										<ds:complexType>
+											<ds:sequence>
+												<ds:element name="Transform">
+													<ds:complexType>
+														<ds:attribute name="Algorithm" type="ds:anyURI" use="required"/>
+													</ds:complexType>
+												</ds:element>
+											</ds:sequence>
+										</ds:complexType>
+									</ds:element>
+									<ds:element name="DigestMethod">
+										<ds:annotation>
+											<ds:documentation>Algoritmo de Digest</ds:documentation>
+										</ds:annotation>
+										<ds:complexType>
+											<ds:attribute name="Algorithm" type="ds:anyURI" use="required" fixed="http://www.w3.org/2000/09/xmldsig#sha1"/>
+										</ds:complexType>
+									</ds:element>
+									<ds:element name="DigestValue" type="ds:base64Binary">
+										<ds:annotation>
+											<ds:documentation>Valor de Digest</ds:documentation>
+										</ds:annotation>
+									</ds:element>
+								</ds:sequence>
+								<ds:attribute name="URI" type="ds:anyURI" use="required"/>
+							</ds:complexType>
+						</ds:element>
+					</ds:sequence>
+				</ds:complexType>
+			</ds:element>
+			<ds:element name="SignatureValue" type="ds:base64Binary">
+				<ds:annotation>
+					<ds:documentation>Valor de la Firma Digital</ds:documentation>
+				</ds:annotation>
+			</ds:element>
+			<ds:element name="KeyInfo">
+				<ds:annotation>
+					<ds:documentation>Informacion de Claves Publicas y Certificado</ds:documentation>
+				</ds:annotation>
+				<ds:complexType>
+					<ds:sequence>
+						<ds:element name="KeyValue">
+							<ds:complexType>
+								<ds:choice>
+									<ds:element name="RSAKeyValue">
+										<ds:annotation>
+											<ds:documentation>Informacion de Claves Publicas RSA</ds:documentation>
+										</ds:annotation>
+										<ds:complexType>
+											<ds:sequence>
+												<ds:element name="Modulus" type="ds:base64Binary">
+													<ds:annotation>
+														<ds:documentation>Modulo Clave RSA</ds:documentation>
+													</ds:annotation>
+												</ds:element>
+												<ds:element name="Exponent" type="ds:base64Binary">
+													<ds:annotation>
+														<ds:documentation>Exponente Clave RSA</ds:documentation>
+													</ds:annotation>
+												</ds:element>
+											</ds:sequence>
+										</ds:complexType>
+									</ds:element>
+									<ds:element name="DSAKeyValue">
+										<ds:annotation>
+											<ds:documentation>Informacion de Claves Publicas DSA</ds:documentation>
+										</ds:annotation>
+										<ds:complexType>
+											<ds:sequence>
+												<ds:element name="P" type="ds:base64Binary">
+													<ds:annotation>
+														<ds:documentation>Modulo Primo</ds:documentation>
+													</ds:annotation>
+												</ds:element>
+												<ds:element name="Q" type="ds:base64Binary">
+													<ds:annotation>
+														<ds:documentation>Entero Divisor de P - 1</ds:documentation>
+													</ds:annotation>
+												</ds:element>
+												<ds:element name="G" type="ds:base64Binary">
+													<ds:annotation>
+														<ds:documentation>Entero f(P, Q)</ds:documentation>
+													</ds:annotation>
+												</ds:element>
+												<ds:element name="Y" type="ds:base64Binary">
+													<ds:annotation>
+														<ds:documentation>G**X mod P</ds:documentation>
+													</ds:annotation>
+												</ds:element>
+											</ds:sequence>
+										</ds:complexType>
+									</ds:element>
+								</ds:choice>
+							</ds:complexType>
+						</ds:element>
+						<ds:element name="X509Data">
+							<ds:annotation>
+								<ds:documentation>Informacion del Certificado Publico</ds:documentation>
+							</ds:annotation>
+							<ds:complexType>
+								<ds:sequence>
+									<ds:element name="X509Certificate" type="ds:base64Binary">
+										<ds:annotation>
+											<ds:documentation>Certificado Publico</ds:documentation>
+										</ds:annotation>
+									</ds:element>
+								</ds:sequence>
+							</ds:complexType>
+						</ds:element>
+					</ds:sequence>
+				</ds:complexType>
+			</ds:element>
+		</ds:sequence>
+	</ds:complexType>
+</ds:schema>

--- a/cl_sii/data/ref/factura_electronica/schema_iecv/LceCal_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schema_iecv/LceCal_v10.xsd
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--  
+	Version 1,  01-08-2005 17:00 version Inicial
+			     25-10-2005 17:00 Se agrega campo "Clase"
+			     27-12-2005 12:00 Se agrega en TipoLCE el valor 6 para Compra y Venta
+-->
+<xs:schema targetNamespace="http://www.sii.cl/SiiLce" xmlns:SiiLce="http://www.sii.cl/SiiLce" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsignature_v10.xsd"/>
+	<xs:include schemaLocation="LceSiiTypes_v10.xsd"/>
+	<xs:element name="LceCal">
+		<xs:annotation>
+			<xs:documentation>Certificado Autorizacion de Libros, generado por el SII</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="DocumentoCal">
+					<xs:annotation>
+						<xs:documentation>Documento de Cal</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="RutDistribuidor" type="SiiLce:RUTType">
+								<xs:annotation>
+									<xs:documentation>RUT Distribuidor</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="TipoCertificado">
+								<xs:annotation>
+									<xs:documentation>Tipo Certificado. C = Certificacion, P=Produccion</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:enumeration value="C">
+											<xs:annotation>
+												<xs:documentation>Certificación. 
+       Se utiliza para efectuar las pruebas de archivos</xs:documentation>
+											</xs:annotation>
+										</xs:enumeration>
+										<xs:enumeration value="P">
+											<xs:annotation>
+												<xs:documentation>Producción.
+ Lo entrega el SII, una vez que se hayan efectuado las pruebas respectivas</xs:documentation>
+											</xs:annotation>
+										</xs:enumeration>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="Clase">
+								<xs:annotation>
+									<xs:documentation>1:Contribuyente, 2:Holding, 3:Empresa de Software.</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:enumeration value="1">
+											<xs:annotation>
+												<xs:documentation>Contribuyente</xs:documentation>
+											</xs:annotation>
+										</xs:enumeration>
+										<xs:enumeration value="2">
+											<xs:annotation>
+												<xs:documentation>Holding</xs:documentation>
+											</xs:annotation>
+										</xs:enumeration>
+										<xs:enumeration value="3">
+											<xs:annotation>
+												<xs:documentation>Empresa Software</xs:documentation>
+											</xs:annotation>
+										</xs:enumeration>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="TipoLCE">
+								<xs:annotation>
+									<xs:documentation>Tipo del Libro Contable. </xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:positiveInteger">
+										<xs:enumeration value="1">
+											<xs:annotation>
+												<xs:documentation>Contable. Incluye, Diario, Mayor, Balance,  Inventarios y Balance </xs:documentation>
+											</xs:annotation>
+										</xs:enumeration>
+										<xs:enumeration value="2">
+											<xs:annotation>
+												<xs:documentation>Remuneraciones</xs:documentation>
+											</xs:annotation>
+										</xs:enumeration>
+										<xs:enumeration value="3">
+											<xs:annotation>
+												<xs:documentation>Honorarios</xs:documentation>
+											</xs:annotation>
+										</xs:enumeration>
+										<xs:enumeration value="4">
+											<xs:annotation>
+												<xs:documentation>Registro de Existencias</xs:documentation>
+											</xs:annotation>
+										</xs:enumeration>
+										<xs:enumeration value="5">
+											<xs:annotation>
+												<xs:documentation>Activo Fijo</xs:documentation>
+											</xs:annotation>
+										</xs:enumeration>
+										<xs:enumeration value="6">
+											<xs:annotation>
+												<xs:documentation>Compra y Venta</xs:documentation>
+											</xs:annotation>
+										</xs:enumeration>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="FchEmision" type="xs:date">
+								<xs:annotation>
+									<xs:documentation>Fecha de Emision del CAL(AAAA-MM-DD)</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="PeriodoVigencia" type="xs:gYear">
+								<xs:annotation>
+									<xs:documentation>En caso que Clase = 3 corresponde al año en que es valido hacer envios con este CAL, de lo contrario es año de inicio para realizar envios. ( Formato AAAA)</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="TmstFirma" type="xs:dateTime">
+								<xs:annotation>
+									<xs:documentation>Fecha y Hora de la Firma </xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="ID" type="xs:ID" use="required"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ds:Signature">
+					<xs:annotation>
+						<xs:documentation>Firma Digital sobre Documento</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="version" type="xs:decimal" use="required" fixed="1.0"/>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/cl_sii/data/ref/factura_electronica/schema_iecv/LceCal_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schema_iecv/LceCal_v10.xsd
@@ -3,8 +3,9 @@
 	Version 1,  01-08-2005 17:00 version Inicial
 			     25-10-2005 17:00 Se agrega campo "Clase"
 			     27-12-2005 12:00 Se agrega en TipoLCE el valor 6 para Compra y Venta
+			     18-04-2007 11:30 Se agrega a Clase el valor 4=Prestador de Libros Contables.
 -->
-<xs:schema targetNamespace="http://www.sii.cl/SiiLce" xmlns:SiiLce="http://www.sii.cl/SiiLce" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xs:schema targetNamespace="http://www.sii.cl/SiiLce" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:SiiLce="http://www.sii.cl/SiiLce" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsignature_v10.xsd"/>
 	<xs:include schemaLocation="LceSiiTypes_v10.xsd"/>
 	<xs:element name="LceCal">
@@ -47,7 +48,7 @@
 							</xs:element>
 							<xs:element name="Clase">
 								<xs:annotation>
-									<xs:documentation>1:Contribuyente, 2:Holding, 3:Empresa de Software.</xs:documentation>
+									<xs:documentation>1:Contribuyente, 2:Holding, 3:Empresa de Software.,4:Prestador de Servicios Contables.</xs:documentation>
 								</xs:annotation>
 								<xs:simpleType>
 									<xs:restriction base="xs:string">
@@ -64,6 +65,11 @@
 										<xs:enumeration value="3">
 											<xs:annotation>
 												<xs:documentation>Empresa Software</xs:documentation>
+											</xs:annotation>
+										</xs:enumeration>
+										<xs:enumeration value="4">
+											<xs:annotation>
+												<xs:documentation>Prestador de Servicios Contables</xs:documentation>
 											</xs:annotation>
 										</xs:enumeration>
 									</xs:restriction>

--- a/cl_sii/data/ref/factura_electronica/schema_iecv/LceCoCertif_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schema_iecv/LceCoCertif_v10.xsd
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--  
+	Version  01-08-2005 17:00 version inicial
+	Version  22-08-2005 09:00 Se corrige error en campo "RutFirmanteDistribuidor"
+-->
+<xs:schema targetNamespace="http://www.sii.cl/SiiLce" xmlns:SiiLce="http://www.sii.cl/SiiLce" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsignature_v10.xsd"/>
+	<xs:include schemaLocation="LceSiiTypes_v10.xsd"/>
+	<xs:include schemaLocation="LceCal_v10.xsd"/>
+	<xs:element name="LceCoCertif">
+		<xs:annotation>
+			<xs:documentation>Comprobante de Certificacion</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="DocumentoCoCertif">
+					<xs:annotation>
+						<xs:documentation>Documento de Comprobante de Certificacion</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="RutContribuyente" type="SiiLce:RUTType">
+								<xs:annotation>
+									<xs:documentation>RUT Contribuyente de los LCE</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="FchEmision" type="xs:date">
+								<xs:annotation>
+									<xs:documentation>Fecha de Emision del Comprobante de Certificacion (AAAA-MM-DD)</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element ref="SiiLce:LceCal"/>
+							<xs:element name="RutFirmanteDistribuidor" type="SiiLce:RUTType">
+								<xs:annotation>
+									<xs:documentation>RUT autorizado por el Distribuidor a firmar este documento.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="TmstFirma" type="xs:dateTime">
+								<xs:annotation>
+									<xs:documentation>Fecha y Hora de la Firma </xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="ID" type="xs:ID" use="required"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ds:Signature">
+					<xs:annotation>
+						<xs:documentation>Firma Digital sobre Documento</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="version" type="xs:decimal" use="required" fixed="1.0"/>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/cl_sii/data/ref/factura_electronica/schema_iecv/LceCoCertif_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schema_iecv/LceCoCertif_v10.xsd
@@ -2,6 +2,7 @@
 <!--  
 	Version  01-08-2005 17:00 version inicial
 	Version  22-08-2005 09:00 Se corrige error en campo "RutFirmanteDistribuidor"
+		 18-04-2007 11:30 Se agrega a Clase el valor 4=Prestador de Libros Contables.
 -->
 <xs:schema targetNamespace="http://www.sii.cl/SiiLce" xmlns:SiiLce="http://www.sii.cl/SiiLce" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsignature_v10.xsd"/>

--- a/cl_sii/data/ref/factura_electronica/schema_iecv/LceSiiTypes_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schema_iecv/LceSiiTypes_v10.xsd
@@ -1,0 +1,280 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--  
+	Version 1,  01-08-2005 17:00 
+                  07-09-2005 16:00 Se cambia "MontoType" con el largo de los decimales de los montos a 4.
+-->
+<xs:schema targetNamespace="http://www.sii.cl/SiiLce" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:simpleType name="RUTType">
+		<xs:annotation>
+			<xs:documentation>Rol Unico Tributario (99..99-X)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="10"/>
+			<xs:minLength value="3"/>
+			<xs:pattern value="[0-9]+-([0-9]|K)"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FolioType">
+		<xs:annotation>
+			<xs:documentation>Folio de DTE - 10 digitos</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:positiveInteger">
+			<xs:totalDigits value="10"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MontoType">
+		<xs:annotation>
+			<xs:documentation>Monto de 18 digitos y 4 decimales</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="18"/>
+			<xs:fractionDigits value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ImptoType">
+		<xs:annotation>
+			<xs:documentation>Impuestos Adicionales</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:positiveInteger">
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>IVA Margen de Comercializacion</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Total</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Parcial</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>IVA Anticipado Faenamiento Carne</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>IVA Anticipado Carne</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>IVA Anticipado Harina</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 37 Letras a, b, c</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 42 Ley 825/74 Letra a</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 42 Letra c</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 42 Letra c</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 42 Letra d y e</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Impuesto Especifico Diesel</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>Recuperacion Impuesto Especifico Diesel Transportistas</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Legumbres</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Silvestres</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Ganado</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Madera</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Trigo</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>Impuesto Especifico Gasolina</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="36">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Arroz</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="37">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Hidrobiologicas</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="38">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Chatarra</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="39">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido PPA</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Opcional</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="44">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 37 Letras e, f, g y h</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="45">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 37 Letra j</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="51"/>
+			<xs:enumeration value="52"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:attribute name="version" type="xs:decimal" fixed="1.0"/>
+	<xs:simpleType name="MntImpType">
+		<xs:annotation>
+			<xs:documentation>Monto 18 digitos (> cero)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:positiveInteger">
+			<xs:totalDigits value="18"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PctType">
+		<xs:annotation>
+			<xs:documentation>Porcentaje (3 enteros y 2 decimales)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="5"/>
+			<xs:fractionDigits value="2"/>
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="100"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DoctoType">
+		<xs:annotation>
+			<xs:documentation>Tipos de Documentos</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:positiveInteger">
+			<xs:enumeration value="30"/>
+			<xs:enumeration value="32"/>
+			<xs:enumeration value="33"/>
+			<xs:enumeration value="34"/>
+			<xs:enumeration value="35"/>
+			<xs:enumeration value="38"/>
+			<xs:enumeration value="39"/>
+			<xs:enumeration value="40"/>
+			<xs:enumeration value="41"/>
+			<xs:enumeration value="43"/>
+			<xs:enumeration value="45"/>
+			<xs:enumeration value="46"/>
+			<xs:enumeration value="55"/>
+			<xs:enumeration value="56"/>
+			<xs:enumeration value="60"/>
+			<xs:enumeration value="61"/>
+			<xs:enumeration value="101"/>
+			<xs:enumeration value="102"/>
+			<xs:enumeration value="103"/>
+			<xs:enumeration value="104"/>
+			<xs:enumeration value="105"/>
+			<xs:enumeration value="106"/>
+			<xs:enumeration value="108"/>
+			<xs:enumeration value="109"/>
+			<xs:enumeration value="900"/>
+			<xs:enumeration value="901"/>
+			<xs:enumeration value="902"/>
+			<xs:enumeration value="903"/>
+			<xs:enumeration value="904"/>
+			<xs:enumeration value="905"/>
+			<xs:enumeration value="906"/>
+			<xs:enumeration value="907"/>
+			<xs:enumeration value="909"/>
+			<xs:enumeration value="910"/>
+			<xs:enumeration value="911"/>
+			<xs:enumeration value="914"/>
+			<xs:enumeration value="918"/>
+			<xs:enumeration value="919"/>
+			<xs:enumeration value="920"/>
+			<xs:enumeration value="921"/>
+			<xs:enumeration value="922"/>
+			<xs:enumeration value="110"/>
+			<xs:enumeration value="111"/>
+			<xs:enumeration value="112"/>
+			<xs:enumeration value="924"/>
+			<xs:enumeration value="500"/>
+			<xs:enumeration value="501"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ValorType">
+		<xs:annotation>
+			<xs:documentation>Monto 18 digitos (positivo o negativo)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:integer">
+			<xs:totalDigits value="18"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="Periodo">
+		<xs:annotation>
+			<xs:documentation>lapso de tiempo. En forma AAAA-MM hasta AAAA-MM</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Inicial" type="xs:gYearMonth">
+				<xs:annotation>
+					<xs:documentation>Inicio del Periodo. En formato AAAA-MM</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Final" type="xs:gYearMonth">
+				<xs:annotation>
+					<xs:documentation>Final del Periodo. Formato AAAA-MM</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="MontoSinDecType">
+		<xs:annotation>
+			<xs:documentation>Monto 18 digitos (mayor o igual a cero)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:nonNegativeInteger">
+			<xs:totalDigits value="18"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/cl_sii/data/ref/factura_electronica/schema_iecv/LceSiiTypes_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schema_iecv/LceSiiTypes_v10.xsd
@@ -2,6 +2,7 @@
 <!--  
 	Version 1,  01-08-2005 17:00 
                   07-09-2005 16:00 Se cambia "MontoType" con el largo de los decimales de los montos a 4.
+                  18-04-2007 11:30 Se agrega a Clase el valor 4=Prestador de Libros Contables.
 -->
 <xs:schema targetNamespace="http://www.sii.cl/SiiLce" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:simpleType name="RUTType">

--- a/cl_sii/data/ref/factura_electronica/schema_iecv/LibroCV_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schema_iecv/LibroCV_v10.xsd
@@ -1,0 +1,1637 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<xs:schema targetNamespace="http://www.sii.cl/SiiDte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:SiiDte="http://www.sii.cl/SiiDte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:SiiLce="http://www.sii.cl/SiiLce" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<!--  Modificacion 31/10/2007 11:18 	 Restricciones a FchDoc (rango de validez 2000 al 2050)
+	       Modificación 08/01/2008   9:17     CdgSIISucur de 8 a 9 digitos
+	       Modificación 21/08/2008  15:08    FolioNotificacion de 18 a 10 digitos
+              Modificación 19/03/2010 12:10     Se agrega al impuesto (53) retenido a los suplementeros
+              Modificación 11/06/2010 10:05	 Se incrementa caracteres de NumId de 15 a 20 (receptor extranjero)
+              Modificación 30/07/10     15:00 	  Se limita a 30.000 documentos el máximo por envio o sobre (de 											   acuerdo a publicación)
+		Modificación 14/02/2011 10:50	 Se incorpora la Factura de Inicio (TpoDoc = 29)
+		Modificación 02/03/2011 12:40	 Se elimina limitacion a 30.000 documentos (detalles).
+ -->
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsignature_v10.xsd"/>
+	<xs:import namespace="http://www.sii.cl/SiiLce" schemaLocation="LceCoCertif_v10.xsd"/>
+	<xs:element name="LibroCompraVenta">
+		<xs:annotation>
+			<xs:documentation>Informacion Electronica de Libros de Compra y Venta</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="EnvioLibro">
+					<xs:annotation>
+						<xs:documentation>Identificacion, Resumen y Detalles del Libro Electronico</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="Caratula">
+								<xs:annotation>
+									<xs:documentation>Identificacion del Envio del Libro Electronico</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="RutEmisorLibro" type="SiiDte:RUTType">
+											<xs:annotation>
+												<xs:documentation>RUT del Emisor del Libro Electronico</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="RutEnvia" type="SiiDte:RUTType">
+											<xs:annotation>
+												<xs:documentation>RUT que Realiza el Envio del Libro Electronico</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="PeriodoTributario" type="xs:gYearMonth">
+											<xs:annotation>
+												<xs:documentation>Periodo Tributario del Libro Electronico (AAAA-MM)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="FchResol" type="xs:date">
+											<xs:annotation>
+												<xs:documentation>Fecha de Resolucion que Autoriza el Envio de Libros (AAAA-MM-DD)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="NroResol">
+											<xs:annotation>
+												<xs:documentation>Numero de Resolucion que Autoriza el Envio de Libros</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:nonNegativeInteger">
+													<xs:totalDigits value="6"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="TipoOperacion">
+											<xs:annotation>
+												<xs:documentation>Tipo de Operacion Declarada en el Libro</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:enumeration value="COMPRA"/>
+													<xs:enumeration value="VENTA"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="TipoLibro">
+											<xs:annotation>
+												<xs:documentation>Tipo de Libro de Compra o Venta Enviado</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:enumeration value="MENSUAL"/>
+													<xs:enumeration value="ESPECIAL"/>
+													<xs:enumeration value="RECTIFICA"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="TipoEnvio">
+											<xs:annotation>
+												<xs:documentation>Tipo de Envio del Libro Electronico</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:minLength value="5"/>
+													<xs:enumeration value="PARCIAL">
+														<xs:annotation>
+															<xs:documentation>Indica que es un Envio Parcial del Libro y que Faltan Otros para Completar el Libro</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="FINAL">
+														<xs:annotation>
+															<xs:documentation>Indica que es el Ultimo Envio Parcial. Con Esto se Completa el Libro.</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="TOTAL">
+														<xs:annotation>
+															<xs:documentation>Indica que es el Unico Envio que Compone el Libro</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="AJUSTE">
+														<xs:annotation>
+															<xs:documentation>Indica que es un Envio con Informacion para Corregir un Libro Previamente Enviado</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="NroSegmento" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Correlativo del Segmento de Libro</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:totalDigits value="6"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="FolioNotificacion" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Folio de la Notificacion con que se Solicita el Libro Especial</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:totalDigits value="10"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="CodAutRec" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Codigo de Autorización de Rectificación</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="10"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="ResumenSegmento" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Resumen del Segmento de Informacion Enviado</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="TotalesSegmento" maxOccurs="40">
+											<xs:annotation>
+												<xs:documentation>Totales de Control, por Tipo de  Documento, Para el Segmento</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="TpoDoc" type="SiiDte:DoctoType">
+														<xs:annotation>
+															<xs:documentation>Tipo de Documento</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TpoImp" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Tipo de Impuesto Resumido (LC)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="1"/>
+																<xs:enumeration value="1">
+																	<xs:annotation>
+																		<xs:documentation>IVA</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="2">
+																	<xs:annotation>
+																		<xs:documentation>Ley 18.211</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotDoc">
+														<xs:annotation>
+															<xs:documentation>Numero de Documentos del Tipo Incluidos en el Libro Electronico</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:integer">
+																<xs:totalDigits value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotAnulado" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Numero de Documentos Anulados </xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:integer">
+																<xs:totalDigits value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotOpExe" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Numero de Operaciones Exentas</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:integer">
+																<xs:totalDigits value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotMntExe" type="SiiDte:ValorType">
+														<xs:annotation>
+															<xs:documentation>Total de los Montos Exentos</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotMntNeto" type="SiiDte:ValorType">
+														<xs:annotation>
+															<xs:documentation>Total de los Montos Netos</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotOpIVARec" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total de Operaciones con IVA Recuperable (LC)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:integer">
+																<xs:totalDigits value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotMntIVA" type="SiiDte:ValorType">
+														<xs:annotation>
+															<xs:documentation>Total de los Montos de IVA (LV) o IVA Recuperable (LC)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotOpActivoFijo" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Numero de Operaciones de Activo Fijo (LC)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:integer">
+																<xs:totalDigits value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotMntActivoFijo" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Monto Neto de las Operaciones de Activo Fijo (LC)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotMntIVAActivoFijo" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total del IVA de las Operaciones de Activo Fijo (LC)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotIVANoRec" minOccurs="0" maxOccurs="5">
+														<xs:annotation>
+															<xs:documentation>Totales de IVA No Recuperable (LC)</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="CodIVANoRec">
+																	<xs:annotation>
+																		<xs:documentation>Codigo de IVA No Recuperable</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="1"/>
+																			<xs:enumeration value="1">
+																				<xs:annotation>
+																					<xs:documentation>Compras destinadas a Generar Operaciones No Gravadas o Exentas</xs:documentation>
+																				</xs:annotation>
+																			</xs:enumeration>
+																			<xs:enumeration value="2">
+																				<xs:annotation>
+																					<xs:documentation>Facturas Registradas Fuera de Plazo</xs:documentation>
+																				</xs:annotation>
+																			</xs:enumeration>
+																			<xs:enumeration value="3">
+																				<xs:annotation>
+																					<xs:documentation>Gastos Rechazados</xs:documentation>
+																				</xs:annotation>
+																			</xs:enumeration>
+																			<xs:enumeration value="4">
+																				<xs:annotation>
+																					<xs:documentation>Entrega Gratuita</xs:documentation>
+																				</xs:annotation>
+																			</xs:enumeration>
+																			<xs:enumeration value="9">
+																				<xs:annotation>
+																					<xs:documentation>Otros</xs:documentation>
+																				</xs:annotation>
+																			</xs:enumeration>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="TotOpIVANoRec" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Numero de Operaciones con IVA No Recuperable</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:integer">
+																			<xs:totalDigits value="10"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="TotMntIVANoRec" type="SiiDte:ValorType">
+																	<xs:annotation>
+																		<xs:documentation>Total de IVA No Recuperable</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="TotOpIVAUsoComun" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Numero de Operaciones con IVA Uso Comun (LC)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:integer">
+																<xs:totalDigits value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotIVAUsoComun" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total IVA Uso Comun (LC)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotIVAFueraPlazo" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total IVA Fuera de Plazo (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotIVAPropio" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total de IVA Propio en Operaciones a Cuenta de Terceros (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotIVATerceros" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total de IVA a Cuenta de Terceros (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotLey18211" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Ley 18.211 (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotOtrosImp" minOccurs="0" maxOccurs="20">
+														<xs:annotation>
+															<xs:documentation>Totales de Otros Impuestos </xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="CodImp" type="SiiDte:ImptoType">
+																	<xs:annotation>
+																		<xs:documentation>Codigo del Otro Impuesto</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="TotMntImp" type="SiiDte:ValorType">
+																	<xs:annotation>
+																		<xs:documentation>Monto del Otro Impuesto</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="TotImpSinCredito" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total  de Impuestos Sin Derecho a Credito (LC)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotOpIVARetTotal" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Numero de Operaciones con IVA Retenido Total (LV)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:integer">
+																<xs:totalDigits value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotIVARetTotal" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total de IVA Retenido Total (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotOpIVARetParcial" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Numero de Operaciones con IVA Retenido Parcial (LV)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:integer">
+																<xs:totalDigits value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotIVARetParcial" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total de IVA Retenido Parcial (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotCredEC" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Credito Empresa Constructora (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotDepEnvase" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total de los Depositos por Envase (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotLiquidaciones" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Info. Elect. de Venta (LV)</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="TotValComNeto" type="SiiDte:ValorType" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor Neto Comisiones y Otros Cargos (LV)</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="TotValComExe" type="SiiDte:ValorType" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Val. Comis. y Otros Cargos no Afectos o Exentos )LV)</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="TotValComIVA" type="SiiDte:ValorType" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor IVA Comisiones y Otros Cargos   (LV)</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="TotMntTotal" type="SiiDte:ValorType">
+														<xs:annotation>
+															<xs:documentation>Total de los Montos Totales</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotOpIVANoRetenido" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Numero de Operaciones con IVA No Retenido (LV)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:integer">
+																<xs:totalDigits value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotIVANoRetenido" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total IVA No Retenido</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotMntNoFact" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total MOnto No Facturable (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotMntPeriodo" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Monto Periodo (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotPsjNac" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Venta Pasaje Nacional (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotPsjInt" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Venta Pasaje Internacional (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotTabPuros" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Tabacos - Puros (LC)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotTabCigarrillos" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Tabacos - Cigarrillos (LC)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotTabElaborado" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Tabacos - Elaborados (LC)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="ResumenPeriodo" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Resumen Para el Periodo Tributario</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="TotalesPeriodo" maxOccurs="40">
+											<xs:annotation>
+												<xs:documentation>Totales de Control, por Tipo de  Documento, Para el Periodo Tributario</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="TpoDoc" type="SiiDte:DoctoType">
+														<xs:annotation>
+															<xs:documentation>Tipo de Documento Resumido</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TpoImp" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Tipo de Impuesto Resumido (LC)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="1"/>
+																<xs:enumeration value="1">
+																	<xs:annotation>
+																		<xs:documentation>IVA</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="2">
+																	<xs:annotation>
+																		<xs:documentation>Ley 18.211</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotDoc">
+														<xs:annotation>
+															<xs:documentation>Numero de Documentos del Tipo Incluidos en el Libro Electronico</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:nonNegativeInteger">
+																<xs:totalDigits value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotAnulado" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Numero de Documentos Anulados </xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotOpExe" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Numero de Operaciones Exentas</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotMntExe" type="SiiDte:ValorType">
+														<xs:annotation>
+															<xs:documentation>Total de los Montos Exentos</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotMntNeto" type="SiiDte:ValorType">
+														<xs:annotation>
+															<xs:documentation>Total de los Montos Netos</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotOpIVARec" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total de Operaciones con IVA Recuperable (LC)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotMntIVA" type="SiiDte:ValorType">
+														<xs:annotation>
+															<xs:documentation>Total de los Montos de IVA</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotOpActivoFijo" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Numero de Operaciones  de Activo Fijo (LC)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotMntActivoFijo" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Monto Neto de Activo Fijo (LC)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotMntIVAActivoFijo" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total del IVA de las Operaciones de Activo Fijo (LC)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotIVANoRec" minOccurs="0" maxOccurs="5">
+														<xs:annotation>
+															<xs:documentation>Tabla de IVA No Recuperable (LC)</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="CodIVANoRec">
+																	<xs:annotation>
+																		<xs:documentation>Codigo de IVA No Recuperable</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:enumeration value="1"/>
+																			<xs:enumeration value="2"/>
+																			<xs:enumeration value="3"/>
+																			<xs:enumeration value="4"/>
+																			<xs:enumeration value="9">
+																				<xs:annotation>
+																					<xs:documentation>Otros</xs:documentation>
+																				</xs:annotation>
+																			</xs:enumeration>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="TotOpIVANoRec" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Numero de Operaciones de IVA No Recuperable</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:positiveInteger">
+																			<xs:totalDigits value="10"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="TotMntIVANoRec" type="SiiDte:MontoType">
+																	<xs:annotation>
+																		<xs:documentation>Total de IVA No Recuperable</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="TotOpIVAUsoComun" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Numero de Opraciones con IVA Uso Comun (LC)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotIVAUsoComun" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total IVA Uso Comun (LC)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="FctProp" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Factor Proporcionalidad IVA (LC)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:decimal">
+																<xs:fractionDigits value="3"/>
+																<xs:totalDigits value="5"/>
+																<xs:maxInclusive value="99.999"/>
+																<xs:minInclusive value="00.001"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotCredIVAUsoComun" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Credito IVA Uso Comun (LC)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotIVAFueraPlazo" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total IVA Fuera de Plazo (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotIVAPropio" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total de IVA Propio en Operaciones a Cuenta de Terceros (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotIVATerceros" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total de IVA a Cuenta de Terceros (LV) </xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotLey18211" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Ley 18211</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotOtrosImp" minOccurs="0" maxOccurs="20">
+														<xs:annotation>
+															<xs:documentation>Totales de Otros Impuestos </xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="CodImp" type="SiiDte:ImptoType">
+																	<xs:annotation>
+																		<xs:documentation>Codigo del Otro Impuesto</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="TotMntImp" type="SiiDte:ValorType">
+																	<xs:annotation>
+																		<xs:documentation>Monto Total del Otro Impuesto</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="FctImpAdic" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Factor Impuesto Adicional (LC)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:decimal">
+																			<xs:totalDigits value="6"/>
+																			<xs:fractionDigits value="4"/>
+																			<xs:maxInclusive value="1.000"/>
+																			<xs:minInclusive value="0.001"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="TotCredImp" type="SiiDte:MontoType" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Total Credito Impuesto (LC)</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="TotImpSinCredito" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total  de Impuestos Sin Derecho a Credito (LC)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotOpIVARetTotal" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Numero de Operaciones con IVA Retenido Total (LV)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotIVARetTotal" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total IVA Retenido Total (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotOpIVARetParcial" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Numero de Operaciones con IVA Retenido Parcial (LV)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotIVARetParcial" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total IVA Retenido Parcial (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotCredEC" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Credito Empresa Constructore (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotDepEnvase" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Deposito Envase (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotLiquidaciones" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Info. Elect. de Venta (LV)</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="TotValComNeto" type="SiiDte:ValorType" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor Neto Comisiones y Otros Cargos (LV)</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="TotValComExe" type="SiiDte:ValorType" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Val. Comis. y Otros Cargos no Afectos o Exentos )LV)</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="TotValComIVA" type="SiiDte:ValorType" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor IVA Comisiones y Otros Cargos   (LV)</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="TotMntTotal" type="SiiDte:ValorType">
+														<xs:annotation>
+															<xs:documentation>Total de los Montos Totales</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotOpIVANoRetenido" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Numero de Operaciones con IVA No Retenido (LV)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:totalDigits value="10"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="TotIVANoRetenido" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total IVA No Retenido</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotMntNoFact" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Monto No Facturable (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotMntPeriodo" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Monto Periodo (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotPsjNac" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Venta PasajeNacional (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotPsjInt" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Venta Pasaje Internacional (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotTabPuros" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Tabaco -Puros (LC)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotTabCigarrillos" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Tabaco - Cigarrillos (LC)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotTabElaborado" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Tabaco - Elaborado (LC)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TotImpVehiculo" type="SiiDte:MontoType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Total Impuesto Vehiculos (LC)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="Detalle" minOccurs="0" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>Detalle de Documentos que Componen el Libro Electronico</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="TpoDoc" type="SiiDte:DoctoType">
+											<xs:annotation>
+												<xs:documentation>Tipo de Documento</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="Emisor" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Indica si NDébito o NCrédito afecta a una Factura de Compra</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:totalDigits value="1"/>
+													<xs:enumeration value="1">
+														<xs:annotation>
+															<xs:documentation>Emitido por el Emisor del Libro de Compra</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="IndFactCompra" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Indica si NDébito o NCrédito afecta a una Factura de Compra</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:totalDigits value="1"/>
+													<xs:enumeration value="1">
+														<xs:annotation>
+															<xs:documentation>Emitido por el Emisor del Libro de Compra</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="NroDoc">
+											<xs:annotation>
+												<xs:documentation>Identificador o Folio del Documento.</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:totalDigits value="10"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="Anulado" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Indica que el Estado del Documento es Anulado</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:enumeration value="A">
+														<xs:annotation>
+															<xs:documentation>Documento Anulado</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="Operacion" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Indica si Agrega o Elimina Informacion</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:enumeration value="1">
+														<xs:annotation>
+															<xs:documentation>Agrega</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="2">
+														<xs:annotation>
+															<xs:documentation>Elimina</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="TpoImp" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Tipo de Impuesto Usado en la Operacion (LC)</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:totalDigits value="1"/>
+													<xs:enumeration value="1">
+														<xs:annotation>
+															<xs:documentation>IVA</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="2">
+														<xs:annotation>
+															<xs:documentation>Ley 18.211</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="TasaImp" type="SiiDte:PctType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Tasa de impuesto usada en la operación</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="NumInt" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Numero Interno</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="10"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="IndServicio" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Indica si Corresponde a un Servicio (LV)</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:enumeration value="1">
+														<xs:annotation>
+															<xs:documentation>Facturacion de Servicios Periodicos Domiciliarios</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="2">
+														<xs:annotation>
+															<xs:documentation>Facturacion de Otros Servicios Periodicos</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+													<xs:enumeration value="3">
+														<xs:annotation>
+															<xs:documentation>Facturacion de Servicios No Periodicos</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="IndSinCosto" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Indicador de Venta sin Costo (LV)</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:enumeration value="1">
+														<xs:annotation>
+															<xs:documentation>Entrega Gratuita</xs:documentation>
+														</xs:annotation>
+													</xs:enumeration>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="FchDoc" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Fecha del Documento (AAAA-MM-DD)</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:date">
+													<xs:minInclusive value="2000-01-01"/>
+													<xs:maxInclusive value="2050-12-31"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="CdgSIISucur" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Codigo de Sucursal Entregado por el SII</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:totalDigits value="9"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="RUTDoc" type="SiiDte:RUTType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>RUT del Contraparte en la Operación Comercial</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="RznSoc" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Razon Social de la Contraparte del Documento</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:maxLength value="50"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="Extranjero" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Receptor Extranjero (LV)</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="NumId" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Num. Identif. Receptor Extranjero (LV)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="20"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="Nacionalidad" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Nacionalidad Recptor Extranjero (LV)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="3"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="TpoDocRef" type="SiiDte:DoctoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Tipo de Documento de Referencia (LV)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="FolioDocRef" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Folio del Documento Referenciado (LV)</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:positiveInteger">
+													<xs:totalDigits value="10"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="MntExe" type="SiiDte:ValorType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Monto Exento o no Gravado del Documento</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="MntNeto" type="SiiDte:ValorType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Monto Neto del Documento</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="MntIVA" type="SiiDte:ValorType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Monto de IVA del Documento</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="MntActivoFijo" type="SiiDte:MontoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Monto Neto Activo Fijo (LC)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="MntIVAActivoFijo" type="SiiDte:MontoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>IVA de la Operacion de Activo Fijo (LC)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="IVANoRec" minOccurs="0" maxOccurs="5">
+											<xs:annotation>
+												<xs:documentation>Tabla de IVA No Recuperable (LC)</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="CodIVANoRec">
+														<xs:annotation>
+															<xs:documentation>Codigo de IVA No Recuperable</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:positiveInteger">
+																<xs:enumeration value="1">
+																	<xs:annotation>
+																		<xs:documentation>Compras Destinadas a Generar Operaciones No Gravadas o Exentas</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="2">
+																	<xs:annotation>
+																		<xs:documentation>Facturas de Proveedores Registradas Fuera de Plazo</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="3">
+																	<xs:annotation>
+																		<xs:documentation>Gastos Rechazados</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="4">
+																	<xs:annotation>
+																		<xs:documentation>Entrega Gratuita</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+																<xs:enumeration value="9">
+																	<xs:annotation>
+																		<xs:documentation>Otros</xs:documentation>
+																	</xs:annotation>
+																</xs:enumeration>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="MntIVANoRec" type="SiiDte:MontoType">
+														<xs:annotation>
+															<xs:documentation>Monto de IVA No Recuperable</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="IVAUsoComun" type="SiiDte:MontoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>IVA de Compras Destinadas en Parte a Ventas Exentas y Afectas (LC)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="IVAFueraPlazo" type="SiiDte:MontoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Solo Nota de Credito Fuera de Plazo (LV)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="IVAPropio" type="SiiDte:ValorType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>IVA Propio en Operaciones a Cuenta de Terceros (LV)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="IVATerceros" type="SiiDte:ValorType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>IVA por Cuenta de Terceros (LV)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="Ley18211" type="SiiDte:MontoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Ley 18211 </xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="OtrosImp" minOccurs="0" maxOccurs="20">
+											<xs:annotation>
+												<xs:documentation>Otros Impuestos o Recargos</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="CodImp" type="SiiDte:ImptoType">
+														<xs:annotation>
+															<xs:documentation>Codigo del Impuesto o Recargo</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="TasaImp" type="SiiDte:PctType">
+														<xs:annotation>
+															<xs:documentation>Tasa del Impuesto o Recargo</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="MntImp" type="SiiDte:ValorType">
+														<xs:annotation>
+															<xs:documentation>Monto del Impuesto o Recargo. En el LC Registrar Solo el Monto Con Derecho a Credito</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="MntSinCred" type="SiiDte:MontoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Monto del Impuesto Sin Derecho a Credito (LC)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="IVARetTotal" type="SiiDte:MontoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>IVA Retenido Total (LV)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="IVARetParcial" type="SiiDte:MontoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>IVA Retenido Parcial (LV)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CredEC" type="SiiDte:MontoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Credito 65% Empresas Constructoras (LV)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="DepEnvase" type="SiiDte:MontoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Deposito por Envase (LV)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="Liquidaciones" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Info. Elect. de Venta (LV)</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="RutEmisor" type="SiiDte:RUTType">
+														<xs:annotation>
+															<xs:documentation>Rut Emisor (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="ValComNeto" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Valor Neto Comisiones y Otros Cargos (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="ValComExe" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Val. Comis. y Otros Cargos no Afectos o Exentos )LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="ValComIVA" type="SiiDte:ValorType" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Valor IVA Comisiones y Otros Cargos   (LV)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="MntTotal" type="SiiDte:ValorType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Monto Total del Documento</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="IVANoRetenido" type="SiiDte:MontoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>IVA No Retenido</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="MntNoFact" type="SiiDte:ValorType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation> Monto No Facturable (LV)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="MntPeriodo" type="SiiDte:ValorType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Total Monto Periodo (LV)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="PsjNac" type="SiiDte:MontoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Venta Pasaje Nacional (LV)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="PsjInt" type="SiiDte:MontoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Venta Pasaje Internacional (LV)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="TabPuros" type="SiiDte:MontoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Tabacos - Puros (LC)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="TabCigarrillos" type="SiiDte:MontoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Tabacos - Cigarrillos (LC)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="TabElaborado" type="SiiDte:MontoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Tabacos - Elaborados (LC)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="ImpVehiculo" type="SiiDte:MontoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Impuesto a Vehiculo (LC)</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:choice minOccurs="0">
+								<xs:element ref="SiiLce:LceCal"/>
+								<xs:element ref="SiiLce:LceCoCertif"/>
+							</xs:choice>
+							<xs:element name="TmstFirma">
+								<xs:annotation>
+									<xs:documentation>Fecha y Hora en formato AAAA-MM-DDTHH24:MI:SS de la Firma Electronica</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:dateTime"/>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="ID" type="xs:ID" use="required"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ds:Signature">
+					<xs:annotation>
+						<xs:documentation>Firma Digital sobre SetDTE</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="version" type="xs:decimal" use="required" fixed="1.0"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:simpleType name="RUTType">
+		<xs:annotation>
+			<xs:documentation>RUT 99999999-X</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:maxLength value="10"/>
+			<xs:minLength value="3"/>
+			<xs:pattern value="[0-9]+-([0-9]|K)"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MontoType">
+		<xs:annotation>
+			<xs:documentation>Monto 18 digitos (mayor o igual a cero)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:nonNegativeInteger">
+			<xs:totalDigits value="18"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ValorType">
+		<xs:annotation>
+			<xs:documentation>Monto 18 digitos (positivo o negativo)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:integer">
+			<xs:totalDigits value="18"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="MntImpType">
+		<xs:annotation>
+			<xs:documentation>Monto 18 digitos (> cero)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:positiveInteger">
+			<xs:totalDigits value="18"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ImptoType">
+		<xs:annotation>
+			<xs:documentation>Impuestos Adicionales</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:positiveInteger">
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>IVA Margen de Comercializacion</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Total</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Parcial</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>IVA Anticipado Faenamiento Carne</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>IVA Anticipado Carne</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>IVA Anticipado Harina</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 37 Letras a, b, c</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 42 Ley 825/74 Letra a</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 42 Letra c</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 42 Letra c</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 42 Letra d y e</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Impuesto Especifico Diesel</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>Recuperacion Impuesto Especifico Diesel Transportistas</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Legumbres</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Silvestres</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Ganado</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Madera</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Trigo</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>Impuesto Especifico Gasolina</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="36">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Arroz</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="37">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Hidrobiologicas</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="38">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Chatarra</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="39">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido PPA</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>IVA Retenido Opcional</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41"/>
+			<xs:enumeration value="44">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 37 Letras e, f, g y h</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="45">
+				<xs:annotation>
+					<xs:documentation>Impuesto Art. 37 Letra j</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="46"/>
+			<xs:enumeration value="47"/>
+			<xs:enumeration value="48"/>
+			<xs:enumeration value="49"/>
+			<xs:enumeration value="50"/>
+			<xs:enumeration value="51"/>
+			<xs:enumeration value="52"/>
+			<xs:enumeration value="53">
+				<xs:annotation>
+					<xs:documentation>Impuesto retenido a los suplementeros Art. 74 N°5</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="60"/>
+			<xs:enumeration value="301"/>
+			<xs:enumeration value="321"/>
+			<xs:enumeration value="331"/>
+			<xs:enumeration value="341"/>
+			<xs:enumeration value="361"/>
+			<xs:enumeration value="371"/>
+			<xs:enumeration value="481"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DoctoType">
+		<xs:annotation>
+			<xs:documentation>Tipos de Documentos</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:positiveInteger">
+			<xs:enumeration value="29"/>
+			<xs:enumeration value="30"/>
+			<xs:enumeration value="32"/>
+			<xs:enumeration value="33"/>
+			<xs:enumeration value="34"/>
+			<xs:enumeration value="35"/>
+			<xs:enumeration value="38"/>
+			<xs:enumeration value="39"/>
+			<xs:enumeration value="40"/>
+			<xs:enumeration value="41"/>
+			<xs:enumeration value="43"/>
+			<xs:enumeration value="45"/>
+			<xs:enumeration value="46"/>
+			<xs:enumeration value="53"/>
+			<xs:enumeration value="55"/>
+			<xs:enumeration value="56"/>
+			<xs:enumeration value="60"/>
+			<xs:enumeration value="61"/>
+			<xs:enumeration value="101"/>
+			<xs:enumeration value="102"/>
+			<xs:enumeration value="103"/>
+			<xs:enumeration value="104"/>
+			<xs:enumeration value="105"/>
+			<xs:enumeration value="106"/>
+			<xs:enumeration value="108"/>
+			<xs:enumeration value="109"/>
+			<xs:enumeration value="110"/>
+			<xs:enumeration value="111"/>
+			<xs:enumeration value="112"/>
+			<xs:enumeration value="175"/>
+			<xs:enumeration value="180"/>
+			<xs:enumeration value="185"/>
+			<xs:enumeration value="900"/>
+			<xs:enumeration value="901"/>
+			<xs:enumeration value="902"/>
+			<xs:enumeration value="903"/>
+			<xs:enumeration value="904"/>
+			<xs:enumeration value="905"/>
+			<xs:enumeration value="906"/>
+			<xs:enumeration value="907"/>
+			<xs:enumeration value="909"/>
+			<xs:enumeration value="910"/>
+			<xs:enumeration value="911"/>
+			<xs:enumeration value="914"/>
+			<xs:enumeration value="918"/>
+			<xs:enumeration value="919"/>
+			<xs:enumeration value="920"/>
+			<xs:enumeration value="921"/>
+			<xs:enumeration value="922"/>
+			<xs:enumeration value="924"/>
+			<xs:enumeration value="500"/>
+			<xs:enumeration value="501"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="PctType">
+		<xs:annotation>
+			<xs:documentation>Porcentaje (3 enteros y 2 decimales)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:decimal">
+			<xs:totalDigits value="5"/>
+			<xs:fractionDigits value="2"/>
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="100"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/cl_sii/data/ref/factura_electronica/schema_iecv/LibroCV_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schema_iecv/LibroCV_v10.xsd
@@ -1,14 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <xs:schema targetNamespace="http://www.sii.cl/SiiDte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:SiiDte="http://www.sii.cl/SiiDte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:SiiLce="http://www.sii.cl/SiiLce" elementFormDefault="qualified" attributeFormDefault="unqualified">
-	<!--  Modificacion 31/10/2007 11:18 	 Restricciones a FchDoc (rango de validez 2000 al 2050)
-	       Modificación 08/01/2008   9:17     CdgSIISucur de 8 a 9 digitos
-	       Modificación 21/08/2008  15:08    FolioNotificacion de 18 a 10 digitos
-              Modificación 19/03/2010 12:10     Se agrega al impuesto (53) retenido a los suplementeros
-              Modificación 11/06/2010 10:05	 Se incrementa caracteres de NumId de 15 a 20 (receptor extranjero)
-              Modificación 30/07/10     15:00 	  Se limita a 30.000 documentos el máximo por envio o sobre (de 											   acuerdo a publicación)
-		Modificación 14/02/2011 10:50	 Se incorpora la Factura de Inicio (TpoDoc = 29)
-		Modificación 02/03/2011 12:40	 Se elimina limitacion a 30.000 documentos (detalles).
- -->
 	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsignature_v10.xsd"/>
 	<xs:import namespace="http://www.sii.cl/SiiLce" schemaLocation="LceCoCertif_v10.xsd"/>
 	<xs:element name="LibroCompraVenta">
@@ -1227,7 +1218,7 @@
 															<xs:documentation>Codigo del Impuesto o Recargo</xs:documentation>
 														</xs:annotation>
 													</xs:element>
-													<xs:element name="TasaImp" type="SiiDte:PctType">
+													<xs:element name="TasaImp" type="SiiDte:PctType" minOccurs="0">
 														<xs:annotation>
 															<xs:documentation>Tasa del Impuesto o Recargo</xs:documentation>
 														</xs:annotation>
@@ -1555,6 +1546,11 @@
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="60"/>
+			<xs:enumeration value="271">
+				<xs:annotation>
+					<xs:documentation>Bebidas analcohólicas y Minerales con elevado contenido de azúcares.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
 			<xs:enumeration value="301"/>
 			<xs:enumeration value="321"/>
 			<xs:enumeration value="331"/>
@@ -1582,6 +1578,7 @@
 			<xs:enumeration value="43"/>
 			<xs:enumeration value="45"/>
 			<xs:enumeration value="46"/>
+			<xs:enumeration value="48"/>
 			<xs:enumeration value="53"/>
 			<xs:enumeration value="55"/>
 			<xs:enumeration value="56"/>

--- a/cl_sii/data/ref/factura_electronica/schema_iecv/README.md
+++ b/cl_sii/data/ref/factura_electronica/schema_iecv/README.md
@@ -1,0 +1,89 @@
+# schema_iecv
+
+This directory contains all the files of `schema_iecv.zip`, plus this text file.
+All the files have been preserved as they were; schemas are in their original text encoding
+(ISO-8859-1) and have not been modified in the slightest way.
+
+The most significant structures are:
+- XML element `LceCal`: "Certificado Autorizacion de Libros, generado por el SII".
+- XML element `LceCoCertif`: "Comprobante de Certificacion".
+- XML element `LibroCompraVenta`: "Informacion Electronica de Libros de Compra y Venta".
+
+Notes:
+- IECV means "Información Electrónica de Libros de Compra y Venta".
+- LCE means "Libros Contables Electrónicos".
+
+
+## Source
+
+[schema_iecv.zip](http://www.sii.cl/factura_electronica/schema_iecv.zip) (2018-11-28),
+referenced from official webpage
+[SII](http://www.sii.cl)
+/ [Factura electrónica](http://www.sii.cl/servicios_online/1039-.html)
+/ [FORMATO XML DE DOCUMENTOS ELECTRÓNICOS](http://www.sii.cl/factura_electronica/formato_xml.htm)
+as
+"[Bajar schema XML de Información Electrónica de Compras y Ventas](http://www.sii.cl/factura_electronica/schema_iecv.zip)".
+
+
+## Contents
+
+
+### Detail
+
+- `LceCal_v10.xsd`
+  - XML target namespace: `http://www.sii.cl/SiiLce`.
+  - XML included/imported schemas: `LceSiiTypes_v10.xsd`, `xmldsignature_v10.xsd`.
+  - XML elements:
+    - `LceCal`: "Certificado Autorizacion de Libros, generado por el SII".
+
+- `LceCoCertif_v10.xsd`:
+  - XML target namespace: `http://www.sii.cl/SiiLce`.
+  - XML included/imported schemas: `LceSiiTypes_v10.xsd`, `LceCal_v10.xsd`, `xmldsignature_v10.xsd`.
+  - XML elements:
+    - `LceCoCertif`: "Comprobante de Certificacion".
+
+- `LceSiiTypes_v10.xsd`:
+  - XML target namespace: `http://www.sii.cl/SiiLce`.
+  - XML included/imported schemas: none.
+  - XML elements: none.
+  - XML data types:
+    - `RUTType`: "Rol Unico Tributario (99..99-X)".
+    - `FolioType`: "Folio de DTE - 10 digitos".
+    - `MontoType`: "Monto de 18 digitos y 4 decimales".
+    - `ImptoType`: "Impuestos Adicionales".
+    - `MntImpType`: "Monto 18 digitos (> cero)".
+    - `PctType`: "Porcentaje (3 enteros y 2 decimales)".
+    - `DoctoType`: "Tipos de Documentos".
+    - `ValorType`: "Monto 18 digitos (positivo o negativo)".
+    - `Periodo`: "lapso de tiempo. En forma AAAA-MM hasta AAAA-MM".
+    - `MontoSinDecType`: "Monto 18 digitos (mayor o igual a cero)".
+
+- `LibroCV_v10.xsd`:
+  - XML target namespace: `http://www.sii.cl/SiiDte` (**not** `http://www.sii.cl/SiiLce`).
+  - XML included/imported schemas: `LceCoCertif_v10.xsd`, `xmldsignature_v10.xsd`.
+  - XML elements:
+    - `LibroCompraVenta`: "Informacion Electronica de Libros de Compra y Venta".
+  - XML data types:
+    - `RUTType`: "RUT 99999999-X".
+    - `MontoType`: "Monto 18 digitos (mayor o igual a cero)".
+    - `ValorType`: "Monto 18 digitos (positivo o negativo)".
+    - `MntImpType`: "Monto 18 digitos (> cero)".
+    - `ImptoType`: "Impuestos Adicionales".
+    - `DoctoType`: "Tipos de Documentos".
+    - `PctType`: "Porcentaje (3 enteros y 2 decimales)".
+
+- `xmldsignature_v10.xsd`:
+  - XML target namespace: `http://www.w3.org/2000/09/xmldsig#`.
+  - XML included/imported schemas: none.
+  - XML elements:
+    - `Signature`: "Firma Digital sobre Documento".
+  - XML data types:
+    - `SignatureType`: "Firma Digital con Restricciones".
+
+
+### Notes
+
+- File `LibroCV_v10.xsd` defines many data types that are already defined in `LceSiiTypes_v10.xsd`.
+- The two enums named `DoctoType` (one in `LibroCV_v10.xsd` and the other in `LceSiiTypes_v10.xsd`)
+  **have different elements**.
+- File `xmldsignature_v10.xsd` is identical to `../schema_dte/xmldsignature_v10.xsd`.

--- a/cl_sii/data/ref/factura_electronica/schema_iecv/README.md
+++ b/cl_sii/data/ref/factura_electronica/schema_iecv/README.md
@@ -16,6 +16,9 @@ Notes:
 
 ## Source
 
+
+### Original & Official
+
 [schema_iecv.zip](http://www.sii.cl/factura_electronica/schema_iecv.zip) (2018-11-28),
 referenced from official webpage
 [SII](http://www.sii.cl)
@@ -23,6 +26,14 @@ referenced from official webpage
 / [FORMATO XML DE DOCUMENTOS ELECTRÓNICOS](http://www.sii.cl/factura_electronica/formato_xml.htm)
 as
 "[Bajar schema XML de Información Electrónica de Compras y Ventas](http://www.sii.cl/factura_electronica/schema_iecv.zip)".
+
+
+### Updates
+
+Unfortunately the files available on SII's website are outdated with respect to the regulations
+(and even with respect to the documentation PDFs published alongside).
+
+Schema files will be updated as necessary, indicating the source in the corresponding commit.
 
 
 ## Contents

--- a/cl_sii/data/ref/factura_electronica/schema_iecv/xmldsignature_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schema_iecv/xmldsignature_v10.xsd
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!-- Schema for XML Signatures
+    http://www.w3.org/2000/09/xmldsig#
+    $Revision: 1.1 $ on $Date: 2002/02/08 20:32:26 $ by $Author: reagle $
+
+    Copyright 2001 The Internet Society and W3C (Massachusetts Institute
+    of Technology, Institut National de Recherche en Informatique et en
+    Automatique, Keio University). All Rights Reserved.
+    http://www.w3.org/Consortium/Legal/
+
+    This document is governed by the W3C Software License [1] as described
+    in the FAQ [2].
+
+    [1] http://www.w3.org/Consortium/Legal/copyright-software-19980720
+    [2] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD 
+
+Fecha ultima actualización : 10-03-05
+
+-->
+<ds:schema targetNamespace="http://www.w3.org/2000/09/xmldsig#" xmlns:xmldsig="http://www.w3.org/2000/09/xmldsig#" xmlns:ds="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<ds:element name="Signature" type="xmldsig:SignatureType">
+		<ds:annotation>
+			<ds:documentation>Firma Digital sobre Documento</ds:documentation>
+		</ds:annotation>
+	</ds:element>
+	<ds:complexType name="SignatureType">
+		<ds:annotation>
+			<ds:documentation>Firma Digital con Restricciones</ds:documentation>
+		</ds:annotation>
+		<ds:sequence>
+			<ds:element name="SignedInfo">
+				<ds:annotation>
+					<ds:documentation>Descripcion de la Informacion Firmada y del Metodo de Firma</ds:documentation>
+				</ds:annotation>
+				<ds:complexType>
+					<ds:sequence>
+						<ds:element name="CanonicalizationMethod">
+							<ds:annotation>
+								<ds:documentation>Algoritmo de Canonicalizacion</ds:documentation>
+							</ds:annotation>
+							<ds:complexType>
+								<ds:attribute name="Algorithm" type="ds:anyURI" use="required" fixed="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+							</ds:complexType>
+						</ds:element>
+						<ds:element name="SignatureMethod">
+							<ds:annotation>
+								<ds:documentation>Algoritmo de Firma</ds:documentation>
+							</ds:annotation>
+							<ds:complexType>
+								<ds:attribute name="Algorithm" use="required">
+									<ds:simpleType>
+										<ds:restriction base="ds:anyURI">
+											<ds:enumeration value="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+											<ds:enumeration value="http://www.w3.org/2000/09/xmldsig#dsa-sha1"/>
+										</ds:restriction>
+									</ds:simpleType>
+								</ds:attribute>
+							</ds:complexType>
+						</ds:element>
+						<ds:element name="Reference">
+							<ds:annotation>
+								<ds:documentation>Referencia a Elemento Firmado</ds:documentation>
+							</ds:annotation>
+							<ds:complexType>
+								<ds:sequence>
+									<ds:element name="Transforms" minOccurs="0">
+										<ds:annotation>
+											<ds:documentation>Algoritmo de Transformacion</ds:documentation>
+										</ds:annotation>
+										<ds:complexType>
+											<ds:sequence>
+												<ds:element name="Transform">
+													<ds:complexType>
+														<ds:attribute name="Algorithm" type="ds:anyURI" use="required"/>
+													</ds:complexType>
+												</ds:element>
+											</ds:sequence>
+										</ds:complexType>
+									</ds:element>
+									<ds:element name="DigestMethod">
+										<ds:annotation>
+											<ds:documentation>Algoritmo de Digest</ds:documentation>
+										</ds:annotation>
+										<ds:complexType>
+											<ds:attribute name="Algorithm" type="ds:anyURI" use="required" fixed="http://www.w3.org/2000/09/xmldsig#sha1"/>
+										</ds:complexType>
+									</ds:element>
+									<ds:element name="DigestValue" type="ds:base64Binary">
+										<ds:annotation>
+											<ds:documentation>Valor de Digest</ds:documentation>
+										</ds:annotation>
+									</ds:element>
+								</ds:sequence>
+								<ds:attribute name="URI" type="ds:anyURI" use="required"/>
+							</ds:complexType>
+						</ds:element>
+					</ds:sequence>
+				</ds:complexType>
+			</ds:element>
+			<ds:element name="SignatureValue" type="ds:base64Binary">
+				<ds:annotation>
+					<ds:documentation>Valor de la Firma Digital</ds:documentation>
+				</ds:annotation>
+			</ds:element>
+			<ds:element name="KeyInfo">
+				<ds:annotation>
+					<ds:documentation>Informacion de Claves Publicas y Certificado</ds:documentation>
+				</ds:annotation>
+				<ds:complexType>
+					<ds:sequence>
+						<ds:element name="KeyValue">
+							<ds:complexType>
+								<ds:choice>
+									<ds:element name="RSAKeyValue">
+										<ds:annotation>
+											<ds:documentation>Informacion de Claves Publicas RSA</ds:documentation>
+										</ds:annotation>
+										<ds:complexType>
+											<ds:sequence>
+												<ds:element name="Modulus" type="ds:base64Binary">
+													<ds:annotation>
+														<ds:documentation>Modulo Clave RSA</ds:documentation>
+													</ds:annotation>
+												</ds:element>
+												<ds:element name="Exponent" type="ds:base64Binary">
+													<ds:annotation>
+														<ds:documentation>Exponente Clave RSA</ds:documentation>
+													</ds:annotation>
+												</ds:element>
+											</ds:sequence>
+										</ds:complexType>
+									</ds:element>
+									<ds:element name="DSAKeyValue">
+										<ds:annotation>
+											<ds:documentation>Informacion de Claves Publicas DSA</ds:documentation>
+										</ds:annotation>
+										<ds:complexType>
+											<ds:sequence>
+												<ds:element name="P" type="ds:base64Binary">
+													<ds:annotation>
+														<ds:documentation>Modulo Primo</ds:documentation>
+													</ds:annotation>
+												</ds:element>
+												<ds:element name="Q" type="ds:base64Binary">
+													<ds:annotation>
+														<ds:documentation>Entero Divisor de P - 1</ds:documentation>
+													</ds:annotation>
+												</ds:element>
+												<ds:element name="G" type="ds:base64Binary">
+													<ds:annotation>
+														<ds:documentation>Entero f(P, Q)</ds:documentation>
+													</ds:annotation>
+												</ds:element>
+												<ds:element name="Y" type="ds:base64Binary">
+													<ds:annotation>
+														<ds:documentation>G**X mod P</ds:documentation>
+													</ds:annotation>
+												</ds:element>
+											</ds:sequence>
+										</ds:complexType>
+									</ds:element>
+								</ds:choice>
+							</ds:complexType>
+						</ds:element>
+						<ds:element name="X509Data">
+							<ds:annotation>
+								<ds:documentation>Informacion del Certificado Publico</ds:documentation>
+							</ds:annotation>
+							<ds:complexType>
+								<ds:sequence>
+									<ds:element name="X509Certificate" type="ds:base64Binary">
+										<ds:annotation>
+											<ds:documentation>Certificado Publico</ds:documentation>
+										</ds:annotation>
+									</ds:element>
+								</ds:sequence>
+							</ds:complexType>
+						</ds:element>
+					</ds:sequence>
+				</ds:complexType>
+			</ds:element>
+		</ds:sequence>
+	</ds:complexType>
+</ds:schema>

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,9 @@ _package_data = {
     'cl_sii': [
         # Indicates that the "typing information" of the package should be distributed.
         'py.typed',
+        # Data files that are not in a sub-package.
+        'data/ref/factura_electronica/schema_dte/*.xsd',
+        'data/ref/factura_electronica/schema_iecv/*.xsd',
     ],
 }
 


### PR DESCRIPTION
Official schemas of entities related to these domain concepts:
- DTE (Documento Tributario Electrónico)
- IECV (Información Electrónica de Libros de Compra y Venta)
- LCE (Libros Contables Electrónicos)

Includes a README file per schema set.

All the files have been preserved as they were; schemas are in their original text encoding (ISO-8859-1) and have not been modified in the slightest way.

Include the XML schema (`.xsd`) files in the distribution packages (source and wheel).

## Original source

Sources (2018-11-28):
http://www.sii.cl/factura_electronica/schema_dte.zip
http://www.sii.cl/factura_electronica/schema_iecv.zip

## Unofficial updates

Update schemas from an unofficial source since the files available on SII's website are outdated with respect to the regulations (and even to the documentation PDFs published alongside).

Source: repository/project "LibreDTE" at https://github.com/LibreDTE/libredte-lib