### PR TITLE
dte.parse: change and improve `clean_dte_xml`

### DIFF
--- a/scripts/clean_dte_xml_file.py
+++ b/scripts/clean_dte_xml_file.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+"""
+Clean DTE XML files.
+
+
+Example for a single file::
+
+    ./scripts/clean_dte_xml_file.py file \
+        'tests/test_data/sii-dte/DTE--76354771-K--33--170.xml' \
+        'tests/test_data/sii-dte/DTE--76354771-K--33--170-clean.xml'
+
+
+Example for all files in a directory::
+
+    ./scripts/clean_dte_xml_file.py dir 'tests/test_data/sii-dte/'
+
+
+"""
+import difflib
+import os
+import pathlib
+import sys
+from typing import Iterable
+
+try:
+    import cl_sii  # noqa: F401
+except ImportError:
+    # If package 'cl-sii' is not installed, try appending the project repo directory to the
+    #   Python path, assuming thath we are in the project repo. If not, it will fail nonetheless.
+    sys.path.append(os.path.dirname(os.path.abspath(__name__)))
+    import cl_sii  # noqa: F401
+
+import cl_sii.dte.parse
+from cl_sii.libs import xml_utils
+
+
+# TODO: log messages instead of print.
+
+
+def clean_dte_xml_file(input_file_path: str, output_file_path: str) -> Iterable[bytes]:
+    with open(input_file_path, mode='rb') as f:
+        file_bytes = f.read()
+
+    xml_doc = xml_utils.parse_untrusted_xml(file_bytes)
+
+    xml_doc_cleaned, modified = cl_sii.dte.parse.clean_dte_xml(
+        xml_doc,
+        set_missing_xmlns=True,
+        remove_doc_personalizado=True,
+    )
+
+    cl_sii.dte.parse.validate_dte_xml(xml_doc_cleaned)
+
+    with open(output_file_path, 'w+b') as f:
+        xml_utils.write_xml_doc(xml_doc_cleaned, f)
+
+    with open(output_file_path, mode='rb') as f:
+        file_bytes_rewritten = f.read()
+
+    # note: another way to compute the difference in a similar format is
+    #   `diff -Naur $input_file_path $output_file_path`
+    file_bytes_diff_gen = difflib.diff_bytes(
+        dfunc=difflib.unified_diff,
+        a=file_bytes.splitlines(),
+        b=file_bytes_rewritten.splitlines())
+
+    return file_bytes_diff_gen
+
+
+def main_single_file(input_file_path: str, output_file_path: str) -> None:
+    file_bytes_diff_gen = clean_dte_xml_file(
+        input_file_path=input_file_path,
+        output_file_path=output_file_path)
+
+    for diff_line in file_bytes_diff_gen:
+        print(diff_line)
+
+
+def main_dir_files(input_files_dir_path: str) -> None:
+    for p in pathlib.Path(input_files_dir_path).iterdir():
+        if not p.is_file():
+            continue
+
+        # e.g. 'an example.xml' -> 'an example.clean.xml'
+        input_file_path = str(p)
+        output_file_path = str(p.with_suffix(f'.clean{p.suffix}'))
+
+        print(f"\n\nWill clean file '{input_file_path}' and save it to '{output_file_path}'.")
+        file_bytes_diff_gen = clean_dte_xml_file(
+            input_file_path=input_file_path,
+            output_file_path=output_file_path)
+
+        print(f"Difference between input and output files:")
+        diff_line = None
+        for diff_line in file_bytes_diff_gen:
+            print(diff_line)
+        if diff_line is None:
+            print(f"No difference.")
+
+
+if __name__ == '__main__':
+    if sys.argv[1] == 'file':
+        main_single_file(
+            input_file_path=sys.argv[2],
+            output_file_path=sys.argv[3])
+    elif sys.argv[1] == 'dir':
+        main_dir_files(
+            input_files_dir_path=sys.argv[2])
+    else:
+        raise ValueError(f"Invalid option: '{sys.argv[1]}'")

--- a/tests/test_dte_parse.py
+++ b/tests/test_dte_parse.py
@@ -1,12 +1,22 @@
+import difflib
+import io
 import unittest
+from datetime import date
+
+import cl_sii.dte.constants
+from cl_sii.libs import xml_utils
+from cl_sii.rut import Rut
 
 from cl_sii.dte.parse import (  # noqa: F401
     clean_dte_xml, parse_dte_xml, validate_dte_xml,
-    DTE_XML_SCHEMA_OBJ, DTE_XMLNS_MAP,
+    _remove_dte_xml_doc_personalizado, _set_dte_xml_missing_xmlns,
+    DTE_XML_SCHEMA_OBJ, DTE_XMLNS, DTE_XMLNS_MAP
 )
 
+from .utils import read_test_file_bytes
 
-# TODO: add a real DTE XML file in 'tests/test_data/dte/'.
+
+_TEST_DTE_NEEDS_CLEAN_FILE_PATH = 'test_data/sii-dte/DTE--76354771-K--33--170.xml'
 
 
 class OthersTest(unittest.TestCase):
@@ -15,11 +25,131 @@ class OthersTest(unittest.TestCase):
         # TODO: implement
         pass
 
+    def test_integration_ok(self) -> None:
+        # TODO: split in separate tests, with more coverage.
+
+        dte_bad_xml_file_path = _TEST_DTE_NEEDS_CLEAN_FILE_PATH
+
+        file_bytes = read_test_file_bytes(dte_bad_xml_file_path)
+        xml_doc = xml_utils.parse_untrusted_xml(file_bytes)
+
+        self.assertEqual(
+            xml_doc.getroottree().getroot().tag,
+            'DTE')
+
+        with self.assertRaises(xml_utils.XmlSchemaDocValidationError) as cm:
+            validate_dte_xml(xml_doc)
+        self.assertSequenceEqual(
+            cm.exception.args,
+            ("Element 'DTE': No matching global declaration available for the validation root., "
+             "line 2", )
+        )
+        # This would raise:
+        # parse_dte_xml(xml_doc)
+
+        xml_doc_cleaned, modified = clean_dte_xml(
+            xml_doc,
+            set_missing_xmlns=True,
+            remove_doc_personalizado=True,
+        )
+        self.assertTrue(modified)
+
+        # This will not raise.
+        validate_dte_xml(xml_doc_cleaned)
+
+        self.assertEqual(
+            xml_doc_cleaned.getroottree().getroot().tag,
+            '{%s}DTE' % DTE_XMLNS)
+
+        f = io.BytesIO()
+        xml_utils.write_xml_doc(xml_doc_cleaned, f)
+        file_bytes_rewritten = f.getvalue()
+        del f
+
+        xml_doc_rewritten = xml_utils.parse_untrusted_xml(file_bytes_rewritten)
+        validate_dte_xml(xml_doc_rewritten)
+        parsed_dte_rewritten = parse_dte_xml(xml_doc_cleaned)
+
+        self.assertDictEqual(
+            dict(parsed_dte_rewritten.as_dict()),
+            dict(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=cl_sii.dte.constants.TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+                fecha_emision_date=date(2019, 4, 1),
+                receptor_rut=Rut('96790240-3'),
+                monto_total=2996301,
+                emisor_razon_social='INGENIERIA ENACON SPA',
+                receptor_razon_social='MINERA LOS PELAMBRES',
+                fecha_vencimiento_date=None,
+            ))
+
+        expected_file_bytes_diff = (
+            b'--- \n',
+            b'+++ \n',
+            b'@@ -1,5 +1,5 @@\n',
+            b'-<?xml version="1.0" encoding="ISO-8859-1"?>',
+            b'-<DTE version="1.0">',
+            b"+<?xml version='1.0' encoding='ISO-8859-1'?>",
+            b'+<DTE xmlns="http://www.sii.cl/SiiDte" version="1.0">',
+            b'   <!-- O Win32 Chrome 73 central VERSION: v20190227 -->',
+            b' <Documento ID="MiPE76354771-13419">',
+            b'     <Encabezado>',
+            b'@@ -59,13 +59,13 @@\n',
+            b'   </Documento>',
+            b' <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">',
+            b' <SignedInfo>',
+            b'-<CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />',  # noqa: E501
+            b'-<SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" />',
+            b'+<CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>',  # noqa: E501
+            b'+<SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>',
+            b' <Reference URI="#MiPE76354771-13419">',
+            b' <Transforms>',
+            b'-<Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />',
+            b'+<Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>',
+            b' </Transforms>',
+            b'-<DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />',
+            b'+<DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>',
+            b' <DigestValue>ij2Qn6xOc2eRx3hwyO/GrzptoBk=</DigestValue>',
+            b' </Reference>',
+            b' </SignedInfo>',
+        )
+
+        file_bytes_diff_gen = difflib.diff_bytes(
+            dfunc=difflib.unified_diff,
+            a=file_bytes.splitlines(),
+            b=file_bytes_rewritten.splitlines())
+        self.assertSequenceEqual(
+            [diff_line for diff_line in file_bytes_diff_gen],
+            expected_file_bytes_diff
+        )
+
 
 class FunctionCleanDteXmlTest(unittest.TestCase):
 
-    # TODO: implement
-    pass
+    def test_clean_dte_xml_ok(self) -> None:
+        # TODO: implement
+        pass
+
+    def test_clean_dte_xml_fail(self) -> None:
+        # TODO: implement
+        pass
+
+    def test__set_dte_xml_missing_xmlns_ok(self) -> None:
+        # TODO: implement
+        pass
+
+    def test__set_dte_xml_missing_xmlns_fail(self) -> None:
+        # TODO: implement
+        pass
+
+    def test__remove_dte_xml_doc_personalizado_ok(self) -> None:
+        # TODO: implement
+        pass
+
+    def test__remove_dte_xml_doc_personalizado_fail(self) -> None:
+        # TODO: implement
+        pass
 
 
 class FunctionParseDteXmlTest(unittest.TestCase):

--- a/tests/test_libs_xml_utils.py
+++ b/tests/test_libs_xml_utils.py
@@ -4,7 +4,7 @@ import lxml.etree
 
 from cl_sii.libs.xml_utils import (  # noqa: F401
     XmlSyntaxError, XmlFeatureForbidden,
-    parse_untrusted_xml, read_xml_schema, validate_xml_doc,
+    parse_untrusted_xml, read_xml_schema, validate_xml_doc, write_xml_doc,
 )
 
 from .utils import read_test_file_bytes
@@ -98,4 +98,10 @@ class FunctionValidateXmlDocTest(unittest.TestCase):
 
     # TODO: implement
 
+    pass
+
+
+class FunctionWriteXmlDocTest(unittest.TestCase):
+
+    # TODO: implement for function 'write_xml_doc'. Consider each of the "observations".
     pass

--- a/tests/test_scripts_clean_dte_xml_file.py
+++ b/tests/test_scripts_clean_dte_xml_file.py
@@ -1,0 +1,2 @@
+
+# TODO: implement tests for script 'clean_dte_xml_file.py'


### PR DESCRIPTION
Augment and improve it to consider more cleaning operations.

## Backwards compatibility

**Breaks compatibility**.

Signature changed from

`clean_dte_xml(xml_doc: lxml.etree.ElementBase) -> bool`

to

`clean_dte_xml(xml_doc: lxml.etree.ElementBase, set_missing_xmlns: bool = False,  remove_doc_personalizado: bool = True) -> Tuple[lxml.etree.ElementBase, bool]`


## Details

- Add `_set_dte_xml_missing_xmlns`.
- Refactor `_remove_dte_xml_doc_personalizado` out of `clean_dte_xml`.

Tests have not been implemented (just a full "integration test" has).