### PR TITLE
data.ref: add XML schemas for "Cesion" (RTC)

### DIFF
--- a/cl_sii/data/ref/factura_electronica/schemas-xml/AEC_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schemas-xml/AEC_v10.xsd
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--Ultima modificación : 22 de Junio 2005-->
+<xs:schema targetNamespace="http://www.sii.cl/SiiDte" xmlns:SiiDte="http://www.sii.cl/SiiDte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="Cesion_v10.xsd"/>
+	<xs:include schemaLocation="DTECedido_v10.xsd"/>
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsignature_v10.xsd"/>
+	<xs:element name="AEC">
+		<xs:annotation>
+			<xs:documentation>Archivo Electronico de Cesion</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="DocumentoAEC">
+					<xs:annotation>
+						<xs:documentation>Documento de AEC</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="Caratula">
+								<xs:annotation>
+									<xs:documentation>Informacion de AEC</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="RutCedente" type="SiiDte:RUTType">
+											<xs:annotation>
+												<xs:documentation>RUT que Genera el Archivo de Transferencias</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="RutCesionario" type="SiiDte:RUTType">
+											<xs:annotation>
+												<xs:documentation>RUT a Quien Va Dirigido el Archivo de Transferencias</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="NmbContacto" type="SiiDte:NombreType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Persona de Contacto para aclarar dudas</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="FonoContacto" type="SiiDte:FonoType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Telefono de Contacto</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="MailContacto" type="SiiDte:MailType" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Correo Electronico de Contacto</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="TmstFirmaEnvio" type="xs:dateTime">
+											<xs:annotation>
+												<xs:documentation>Fecha y Hora de la Firma del Archivo de Transferencias</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+									<xs:attribute name="version" type="xs:decimal" use="required" fixed="1.0"/>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="Cesiones">
+								<xs:annotation>
+									<xs:documentation>Cesiones</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element ref="SiiDte:DTECedido">
+											<xs:annotation>
+												<xs:documentation>Representacion XML y Grafica del DTE Cedido</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element ref="SiiDte:Cesion" maxOccurs="40">
+											<xs:annotation>
+												<xs:documentation>Informacion Electronica de Recepcion y Aceptacion del DTE por Parte del Receptor</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+						<xs:attribute name="ID" type="xs:ID" use="required"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="ds:Signature">
+					<xs:annotation>
+						<xs:documentation>Firma Digital sobre Transferencia</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="version" type="xs:string" use="required" fixed="1.0"/>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/cl_sii/data/ref/factura_electronica/schemas-xml/Cesion_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schemas-xml/Cesion_v10.xsd
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--Ultima Modificacion:  11 Diciembre 2008 -->
+<xs:schema targetNamespace="http://www.sii.cl/SiiDte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:SiiDte="http://www.sii.cl/SiiDte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="SiiTypes_v10.xsd"/>
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsignature_v10.xsd"/>
+	<!-- 
+      Fecha ultima actualización : 10-03-05 16:00
+       -->
+	<xs:element name="Cesion" type="SiiDte:CesionDefType">
+		<xs:annotation>
+			<xs:documentation>Envio de Informacion de Transferencias  Electronicas</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:complexType name="CesionDefType">
+		<xs:annotation>
+			<xs:documentation>Documento Tributario Electronico</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="DocumentoCesion">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="SeqCesion">
+							<xs:annotation>
+								<xs:documentation>Secuencia de Cesiones (1, 2, 3, ... )</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:positiveInteger">
+									<xs:totalDigits value="3"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="IdDTE">
+							<xs:annotation>
+								<xs:documentation>Identificacion del DTE Cedido</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="TipoDTE" type="SiiDte:DTEFacturasType">
+										<xs:annotation>
+											<xs:documentation>Tipo de DTE</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="RUTEmisor" type="SiiDte:RUTType">
+										<xs:annotation>
+											<xs:documentation>RUT Emisor del DTE</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="RUTReceptor" type="SiiDte:RUTType">
+										<xs:annotation>
+											<xs:documentation>RUT Receptor del DTE</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="Folio" type="SiiDte:FolioType">
+										<xs:annotation>
+											<xs:documentation>Folio del DTE</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="FchEmis" type="xs:date">
+										<xs:annotation>
+											<xs:documentation>Fecha Emision Contable del DTE (AAAA-MM-DD)</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="MntTotal" type="SiiDte:MontoType">
+										<xs:annotation>
+											<xs:documentation>Monto Total del DTE</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="Cedente">
+							<xs:annotation>
+								<xs:documentation>Identificacion del Cedente</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="RUT" type="SiiDte:RUTType">
+										<xs:annotation>
+											<xs:documentation>RUT del Cedente del DTE</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="RazonSocial">
+										<xs:annotation>
+											<xs:documentation>Razon Social o Nombre del Cedente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="SiiDte:RznSocLargaType">
+												<xs:minLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="Direccion">
+										<xs:annotation>
+											<xs:documentation>Direccion del Cedente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="SiiDte:DireccType">
+												<xs:minLength value="5"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="eMail">
+										<xs:annotation>
+											<xs:documentation>Correo Electronico del Cedente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="SiiDte:MailType">
+												<xs:minLength value="6"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="RUTAutorizado" maxOccurs="3">
+										<xs:annotation>
+											<xs:documentation>Lista de Personas Autorizadas por el Cedente a Firmar la Transferencia</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="RUT" type="SiiDte:RUTType">
+													<xs:annotation>
+														<xs:documentation>RUT de Persona Autorizada</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="Nombre" type="SiiDte:NombreType">
+													<xs:annotation>
+														<xs:documentation>Nombre de Persona Autorizada</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="DeclaracionJurada" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Declaracion Jurada de Disponibilidad de Documentacion No Electronica</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:maxLength value="512"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="Cesionario">
+							<xs:annotation>
+								<xs:documentation>Identificacion del Cesionario</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="RUT">
+										<xs:annotation>
+											<xs:documentation>RUT del Cesionario</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="RazonSocial">
+										<xs:annotation>
+											<xs:documentation>Razon Social o Nombre del Cesionario</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="SiiDte:RznSocLargaType">
+												<xs:minLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="Direccion">
+										<xs:annotation>
+											<xs:documentation>Direccion del Cesionario</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="SiiDte:DireccType">
+												<xs:minLength value="5"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="eMail">
+										<xs:annotation>
+											<xs:documentation>Correo Electronico del Cesionario</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="SiiDte:MailType">
+												<xs:minLength value="6"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="MontoCesion" type="SiiDte:MontoType">
+							<xs:annotation>
+								<xs:documentation>Monto del Credito Cedido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="UltimoVencimiento" type="xs:date">
+							<xs:annotation>
+								<xs:documentation>Fecha de Ultimo Vencimiento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="OtrasCondiciones" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Otras Condiciones de la Cesion</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:maxLength value="512"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="eMailDeudor" type="SiiDte:MailType" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Correo Electronico del Deudor del DTE</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="TmstCesion" type="xs:dateTime">
+							<xs:annotation>
+								<xs:documentation>TimeStamp de la Cesion del DTE</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="ID" type="xs:ID" use="required"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" maxOccurs="3">
+				<xs:annotation>
+					<xs:documentation>Firmas Digitales sobre Cesion</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="version" type="xs:decimal" use="required" fixed="1.0"/>
+	</xs:complexType>
+</xs:schema>

--- a/cl_sii/data/ref/factura_electronica/schemas-xml/DTECedido_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schemas-xml/DTECedido_v10.xsd
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--Ultima Modificacion:  09-01-2013 10:00 - se agrega ImagenAR -->
+<xs:schema targetNamespace="http://www.sii.cl/SiiDte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:SiiDte="http://www.sii.cl/SiiDte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="DTE_v10.xsd"/>
+	<xs:include schemaLocation="Recibos_v10.xsd"/>
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsignature_v10.xsd"/>
+	<xs:element name="DTECedido" type="SiiDte:DTECedidoDefType">
+		<xs:annotation>
+			<xs:documentation>DTE con Imagen y Recibos</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:complexType name="DTECedidoDefType">
+		<xs:sequence>
+			<xs:element name="DocumentoDTECedido">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element ref="SiiDte:DTE">
+							<xs:annotation>
+								<xs:documentation>Representacion XML del DTE Cedido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="ImagenDTE" type="xs:base64Binary" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Representacion PDF del DTE Cedido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element ref="SiiDte:Recibo" minOccurs="0" maxOccurs="40">
+							<xs:annotation>
+								<xs:documentation>Informacion Electronica de Recepcion y Aceptacion del DTE por Parte del Receptor</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="ImagenAR" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Representacion PDF del los Acuse de Recibo</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:base64Binary">
+									<xs:maxLength value="4000000"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="TmstFirma" type="xs:dateTime">
+							<xs:annotation>
+								<xs:documentation>Fecha y Hora en que se Firmo Digitalmente el Documento Cedido AAAA-MM-DDTHH:MI:SS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="ID" type="xs:ID" use="required"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature">
+				<xs:annotation>
+					<xs:documentation>Firma Digital sobre Documento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="version" type="xs:string" use="required" fixed="1.0"/>
+	</xs:complexType>
+</xs:schema>

--- a/cl_sii/data/ref/factura_electronica/schemas-xml/README.md
+++ b/cl_sii/data/ref/factura_electronica/schemas-xml/README.md
@@ -17,6 +17,8 @@ The most significant structures are:
 
 Note:
 - DTE means "Documento Tributario Electrónico".
+- RTC: "Registro Transferencia de Crédito" aka RPETC; "Registro Electrónico de Cesión de Créditos".
+- RPETC: "Registro Público Electrónico de Transferencia de Crédito" aka RTC.
 - IECV means "Información Electrónica de Libros de Compra y Venta".
 - LCE means "Libros Contables Electrónicos".
 
@@ -39,6 +41,23 @@ referenced from official webpage
 / [FORMATO XML DE DOCUMENTOS ELECTRÓNICOS](http://www.sii.cl/factura_electronica/formato_xml.htm)
 as
 "[Bajar schema XML de Documentos Tributarios Electrónicos](http://www.sii.cl/factura_electronica/schema_dte.zip) (Incluye Documentos de exportación)"
+
+
+#### Cesion (RTC)
+
+Archive [schema_cesion.zip](http://www.sii.cl/factura_electronica/schema_cesion.zip),
+referenced from official webpage
+[SII](http://www.sii.cl)
+/ [Servicios online](http://www.sii.cl/servicios_online/index.html)
+/ [Factura electrónica](http://www.sii.cl/servicios_online/1039-.html)
+/ [Sistema de facturación de mercado](http://www.sii.cl/servicios_online/1039-1184.html)
+/ [Registro electrónico de cesión de créditos](https://palena.sii.cl/rtc/RTC/RTCMenu.html)
+/ [Formatos de archivos electrónicos](http://www.sii.cl/factura_electronica/form_ele.htm)
+as
+"[Formato XML del Archivo Electrónico de Cesión](http://www.sii.cl/factura_electronica/schema_cesion.zip)"
+
+- Retrieval date: 2019-04-16
+- MD5 checksum: `82d426fc3bd5f3a29e61a1d07ed4d6dd`.
 
 
 #### IECV
@@ -135,6 +154,82 @@ Schema files will be updated as necessary, indicating the source in the correspo
     - `Dec6_4Type`: "Monto con 6 Digitos de Cuerpo y 4 Decimales".
     - `Dec12_6Type`: "Monto con 12 Digitos de Cuerpo y 6 Decimales".
     - `PctType`: "Monto de Porcentaje ( 3 y 2)".
+
+
+#### Cesion (RTC)
+
+- `AEC_v10.xsd`: main schema; it includes (directly or indirectly) all the others of this section.
+  - XML target namespace: `http://www.sii.cl/SiiDte`.
+  - XML included/imported schemas: `Cesion_v10.xsd`, `DTECedido_v10.xsd`, `xmldsignature_v10.xsd`.
+  - XML elements:
+    - `AEC`: "Archivo Electronico de Cesion"
+      - `DocumentoAEC`: "Documento de AEC"
+        - `Caratula`: "Informacion de AEC"
+        - `Cesiones`: "Cesiones"
+          - ref `DTECedido`: "Representacion XML y Grafica del DTE Cedido"
+          - ref `Cesion` (1..N occurrences):
+            "Informacion Electronica de Recepcion y Aceptacion del DTE por Parte del Receptor"
+  - XML data types: no explicit definitions.
+
+- `Cesion_v10.xsd`: ?
+  - XML target namespace: `http://www.sii.cl/SiiDte`.
+  - XML included/imported schemas: `SiiTypes_v10.xsd`, `xmldsignature_v10.xsd`.
+  - XML elements:
+    - `Cesion`: "Envio de Informacion de Transferencias  Electronicas".
+  - XML data types:
+    - `CesionDefType`: "Documento Tributario Electronico" (sic).
+      Relevant elements:
+      - `DocumentoCesion`: (no description nor annotations)
+        - `SeqCesion`: "Secuencia de Cesiones (1, 2, 3, ... )".
+        - `IdDTE`: "Identificacion del DTE Cedido".
+        - `Cedente`: "Identificacion del Cedente".
+        - `Cesionario`: "Identificacion del Cesionario".
+        - `MontoCesion`: "Monto del Credito Cedido".
+        - `UltimoVencimiento`: "Fecha de Ultimo Vencimiento".
+        - `OtrasCondiciones`: "Otras Condiciones de la Cesion".
+        - `eMailDeudor`: "Correo Electronico del Deudor del DTE".
+        - `TmstCesion`: "TimeStamp de la Cesion del DTE".
+
+- `DTECedido_v10.xsd`: ?
+  - XML target namespace: `http://www.sii.cl/SiiDte`.
+  - XML included/imported schemas: `DTE_v10.xsd`, `Recibos_v10.xsd`, `xmldsignature_v10.xsd`.
+  - XML elements:
+    - `DTECedido`: "DTE con Imagen y Recibos".
+  - XML data types:
+    - `DTECedidoDefType`: "Documento Tributario Electronico".
+      Relevant elements:
+      - `DocumentoDTECedido`: (no description nor annotations)
+        - ref `DTE`: "Representacion XML del DTE Cedido".
+        - `ImagenDTE` (optional): "Representacion PDF del DTE Cedido" (binary as base64)
+        - ref `Recibo` (0..N occurrences):
+          "Informacion Electronica de Recepcion y Aceptacion del DTE por Parte del Receptor".
+        - `ImagenAR` (optional):
+          "Representacion PDF del los Acuse de Recibo" (sic) (binary as base64)
+        - `TmstFirma`:
+          "Fecha y Hora en que se Firmo Digitalmente el Documento Cedido AAAA-MM-DDTHH:MI:SS".
+
+- `Recibos_v10.xsd`: ?
+  - XML target namespace: `http://www.sii.cl/SiiDte`.
+  - XML included/imported schemas: `SiiTypes_v10.xsd`, `xmldsignature_v10.xsd`.
+  - XML elements:
+    - `Recibo`:
+        doc 1: "Comprobante de Recepcion de Mercaderias o Servicios Prestados".
+        doc 2: "Recibos de Recepcion de Mercaderias o Servicios Prestados".
+  - XML data types:
+    - `ReciboDefType`: "Documento Tributario Electronico" (sic)
+      Relevant elements:
+      - `DocumentoRecibo`: "Identificacion del Documento Recibido" (sic)
+        - `TipoDoc`: "Tipo de Documento".
+        - `Folio`: "Folio del Documento".
+        - `FchEmis`: "Fecha Emision Contable del Documento (AAAA-MM-DD)".
+        - `RUTEmisor`: "RUT Emisor del Documento".
+        - `RUTRecep`: "RUT Receptor del Documento".
+        - `MntTotal`: "Monto Total del Documento".
+        - `Recinto`: "Lugar donde se materializa la recepción conforme".
+        - `RutFirma`: "RUT de quien Firma el Recibo".
+        - `Declaracion` (fixed string):
+          "Texto Ley 19.983, acredita la recepcion mercaderías o servicio.".
+        - `TmstFirmaRecibo`: "Fecha y Hora de la Firma del Recibo".
 
 
 #### IECV

--- a/cl_sii/data/ref/factura_electronica/schemas-xml/Recibos_v10.xsd
+++ b/cl_sii/data/ref/factura_electronica/schemas-xml/Recibos_v10.xsd
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--Ultima modificación : 15-06-05 10:30 -->
+<xs:schema targetNamespace="http://www.sii.cl/SiiDte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:SiiDte="http://www.sii.cl/SiiDte" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="SiiTypes_v10.xsd"/>
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsignature_v10.xsd"/>
+	<xs:element name="Recibo" type="SiiDte:ReciboDefType">
+		<xs:annotation>
+			<xs:documentation>Comprobante de Recepcion de Mercaderias o Servicios Prestados</xs:documentation>
+			<xs:documentation>Recibos de Recepcion de Mercaderias o Servicios Prestados</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:complexType name="ReciboDefType">
+		<xs:annotation>
+			<xs:documentation>Documento Tributario Electronico</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="DocumentoRecibo">
+				<xs:annotation>
+					<xs:documentation>Identificacion del Documento Recibido</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="TipoDoc" type="SiiDte:DocType">
+							<xs:annotation>
+								<xs:documentation>Tipo de Documento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="Folio" type="SiiDte:FolioType">
+							<xs:annotation>
+								<xs:documentation>Folio del Documento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="FchEmis" type="xs:date">
+							<xs:annotation>
+								<xs:documentation>Fecha Emision Contable del Documento (AAAA-MM-DD)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="RUTEmisor" type="SiiDte:RUTType">
+							<xs:annotation>
+								<xs:documentation>RUT Emisor del Documento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="RUTRecep" type="SiiDte:RUTType">
+							<xs:annotation>
+								<xs:documentation>RUT Receptor del Documento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="MntTotal" type="SiiDte:MontoType">
+							<xs:annotation>
+								<xs:documentation>Monto Total del Documento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="Recinto">
+							<xs:annotation>
+								<xs:documentation>Lugar donde se materializa la recepción conforme  </xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:maxLength value="80"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="RutFirma" type="SiiDte:RUTType">
+							<xs:annotation>
+								<xs:documentation>RUT de quien Firma el Recibo</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="Declaracion" fixed="El acuse de recibo que se declara en este acto, de acuerdo a lo dispuesto en la letra b) del Art. 4, y la letra c) del Art. 5 de la Ley 19.983, acredita que la entrega de mercaderias o servicio(s) prestado(s) ha(n) sido recibido(s).">
+							<xs:annotation>
+								<xs:documentation>Texto Ley 19.983, acredita la recepcion mercaderías o servicio.</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:maxLength value="256"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="TmstFirmaRecibo" type="xs:dateTime">
+							<xs:annotation>
+								<xs:documentation>Fecha y Hora de la Firma del Recibo</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="ID" type="xs:ID" use="required"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature">
+				<xs:annotation>
+					<xs:documentation>Firma Digital sobre Documento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="version" type="xs:decimal" use="required" fixed="1.0"/>
+	</xs:complexType>
+</xs:schema>


### PR DESCRIPTION
"Formato XML del Archivo Electrónico de Cesión" of the "Registro electrónico de cesión de créditos".

Source (2019-04-16): http://www.sii.cl/factura_electronica/schema_cesion.zip

Some files were ignored:
- `DTE_v10.xsd`: there is a newer version in the repo.
- `SiiTypes_v10.xsd`: there is a newer version in the repo.
- `xmldsignature_v10.xsd`: identical to the version in the repo.

The included files are up to date with respect to those in repository/project ["LibreDTE" (39156263)](https://github.com/LibreDTE/libredte-lib/tree/39156263/schemas)

MD5 checksums:
- `82d426fc3bd5f3a29e61a1d07ed4d6dd  schema_cesion.zip`
- `8e80522d91bcf99077c12e15354eeae4  schema_cesion/AEC_v10.xsd`
- `8db534d686bc84fc7960199dd5fdacd8  schema_cesion/Cesion_v10.xsd`
- `b2fd1907af733ae9401604c694837a85  schema_cesion/DTECedido_v10.xsd`
- `e72ee34d798224f31a5127edda712bbf  schema_cesion/DTE_v10.xsd`
- `620cf4867d8ba9c16dba74ab05830963  schema_cesion/Recibos_v10.xsd`
- `b6a63aa427e3d528e46a7d94ccbdcb32  schema_cesion/SiiTypes_v10.xsd`
- `8b83aaae477a57d829b075230237102c  schema_cesion/xmldsignature_v10.xsd`