### PR TITLE
dte: many improvements

### DIFF
--- a/cl_sii/dte/constants.py
+++ b/cl_sii/dte/constants.py
@@ -72,7 +72,7 @@ DTE_TIPO_DTE_FIELD_MIN_VALUE = 1
 class TipoDteEnum(enum.IntEnum):
 
     """
-    Enum of Tipo de DTE.
+    Enum of "Tipo de DTE".
 
     Source: XML type ``DTEType`` (enum) in official schema ``SiiTypes_v10.xsd``.
     https://github.com/fyndata/lib-cl-sii-python/blob/f57a326/cl_sii/data/ref/factura_electronica/schemas-xml/SiiTypes_v10.xsd#L63-L99
@@ -80,21 +80,78 @@ class TipoDteEnum(enum.IntEnum):
     """
 
     FACTURA_ELECTRONICA = 33
-    """Factura Electrónica."""
+    """Factura electrónica de venta."""
 
     FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA = 34
-    """Factura no Afecta o Exenta Electrónica."""
+    """Factura electrónica de venta, no afecta o exenta de IVA."""
+    # aka 'Factura no Afecta o Exenta Electrónica'
     # aka 'Factura Electrónica de Venta de Bienes y Servicios No afectos o Exento de IVA'
 
     FACTURA_COMPRA_ELECTRONICA = 46
-    """Factura de Compra Electrónica."""
+    """Factura electrónica de compra."""
+    # aka 'Factura de Compra Electrónica'
     # Name should have been 'Factura Electrónica de Compra'.
 
     GUIA_DESPACHO_ELECTRONICA = 52
-    """Guía de Despacho Electrónica."""
+    """Guía electrónica de despacho."""
+    # aka 'Guía de Despacho Electrónica'
 
     NOTA_DEBITO_ELECTRONICA = 56
-    """Nota de Débito Electrónica."""
+    """Nota electrónica de débito."""
+    # aka 'Nota de Débito Electrónica'
 
     NOTA_CREDITO_ELECTRONICA = 61
-    """Nota de Crédito Electrónica."""
+    """Nota electrónica de crédito."""
+    # aka 'Nota de Crédito Electrónica'
+
+    @property
+    def is_factura(self) -> bool:
+        if self is TipoDteEnum.FACTURA_ELECTRONICA:
+            result = True
+        elif self is TipoDteEnum.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA:
+            result = True
+        elif self is TipoDteEnum.FACTURA_COMPRA_ELECTRONICA:
+            result = True
+        else:
+            result = False
+
+        return result
+
+    @property
+    def is_factura_venta(self) -> bool:
+        if self is TipoDteEnum.FACTURA_ELECTRONICA:
+            result = True
+        elif self is TipoDteEnum.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA:
+            result = True
+        else:
+            result = False
+
+        return result
+
+    @property
+    def is_factura_compra(self) -> bool:
+        if self is TipoDteEnum.FACTURA_COMPRA_ELECTRONICA:
+            result = True
+        else:
+            result = False
+
+        return result
+
+    @property
+    def is_nota(self) -> bool:
+        if self is TipoDteEnum.NOTA_DEBITO_ELECTRONICA:
+            result = True
+        elif self is TipoDteEnum.NOTA_CREDITO_ELECTRONICA:
+            result = True
+        else:
+            result = False
+
+        return result
+
+    @property
+    def emisor_is_vendedor(self) -> bool:
+        return self.is_factura_venta
+
+    @property
+    def receptor_is_vendedor(self) -> bool:
+        return self.is_factura_compra

--- a/cl_sii/dte/data_models.py
+++ b/cl_sii/dte/data_models.py
@@ -17,7 +17,7 @@ In the domain of a DTE, a:
 """
 import dataclasses
 from dataclasses import field as dc_field
-from datetime import date
+from datetime import date, datetime
 from typing import Mapping, Optional
 
 import cl_sii.contribuyente.constants
@@ -72,6 +72,16 @@ def validate_contribuyente_razon_social(value: str) -> None:
 
     if len(value) > cl_sii.contribuyente.constants.RAZON_SOCIAL_LONG_MAX_LENGTH:
         raise ValueError("Value exceeds max allowed length.")
+
+
+def validate_clean_str(value: str) -> None:
+    if len(value.strip()) != len(value):
+        raise ValueError("Value has leading or trailing whitespace characters.", value)
+
+
+def validate_non_empty_str(value: str) -> None:
+    if len(value.strip()) == 0:
+        raise ValueError("String (stripped) length is 0.")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -312,6 +322,36 @@ class DteDataL2(DteDataL1):
     "Fecha de vencimiento (pago)" of the DTE.
     """
 
+    firma_documento_dt_naive: Optional[datetime] = dc_field(default=None)
+    """
+    Datetime on which the "documento" was digitally signed.
+    """
+
+    signature_value_base64: Optional[str] = dc_field(default=None)
+    """
+    DTE's digital signature's value (as base64 str).
+    """
+
+    signature_x509_cert_base64: Optional[str] = dc_field(default=None)
+    """
+    DTE's digital signature's X509 certificate (as base64 str).
+    """
+
+    emisor_giro: Optional[str] = dc_field(default=None)
+    """
+    "Giro" of the "emisor" of the DTE.
+    """
+
+    emisor_email: Optional[str] = dc_field(default=None)
+    """
+    Email address of the "emisor" of the DTE.
+    """
+
+    receptor_email: Optional[str] = dc_field(default=None)
+    """
+    Email address of the "receptor" of the DTE.
+    """
+
     def __post_init__(self) -> None:
         """
         Run validation automatically after setting the fields values.
@@ -332,3 +372,41 @@ class DteDataL2(DteDataL1):
         if self.fecha_vencimiento_date is not None:
             if not isinstance(self.fecha_vencimiento_date, date):
                 raise TypeError("Inappropriate type of 'fecha_vencimiento_date'.")
+
+        if self.firma_documento_dt_naive is not None:
+            if not isinstance(self.firma_documento_dt_naive, datetime):
+                raise TypeError("Inappropriate type of 'firma_documento_dt_naive'.")
+
+        if self.signature_value_base64 is not None:
+            if not isinstance(self.signature_value_base64, str):
+                raise TypeError("Inappropriate type of 'signature_value_base64'.")
+            # TODO: validate that it is base64
+            # TODO: bytes?
+            validate_clean_str(self.signature_value_base64)
+            validate_non_empty_str(self.signature_value_base64)
+
+        if self.signature_x509_cert_base64 is not None:
+            if not isinstance(self.signature_x509_cert_base64, str):
+                raise TypeError("Inappropriate type of 'signature_x509_cert_base64'.")
+            # TODO: validate that it is base64
+            # TODO: bytes?
+            validate_clean_str(self.signature_x509_cert_base64)
+            validate_non_empty_str(self.signature_x509_cert_base64)
+
+        if self.emisor_giro is not None:
+            if not isinstance(self.emisor_giro, str):
+                raise TypeError("Inappropriate type of 'emisor_giro'.")
+            validate_clean_str(self.emisor_giro)
+            validate_non_empty_str(self.emisor_giro)
+
+        if self.emisor_email is not None:
+            if not isinstance(self.emisor_email, str):
+                raise TypeError("Inappropriate type of 'emisor_email'.")
+            validate_clean_str(self.emisor_email)
+            validate_non_empty_str(self.emisor_email)
+
+        if self.receptor_email is not None:
+            if not isinstance(self.receptor_email, str):
+                raise TypeError("Inappropriate type of 'receptor_email'.")
+            validate_clean_str(self.receptor_email)
+            validate_non_empty_str(self.receptor_email)

--- a/cl_sii/dte/data_models.py
+++ b/cl_sii/dte/data_models.py
@@ -1,3 +1,20 @@
+"""
+DTE data models
+===============
+
+Concepts
+--------
+
+In the domain of a DTE, a:
+
+* "Vendedor": is who sold goods or services to "deudor" in a
+  transaction for which the DTE was issued.
+  It *usually* corresponds to the DTE's "emisor", but not always.
+* "Deudor": is who purchased goods or services from "vendedor" in a
+  transaction for which the DTE was issued.
+  It *usually* corresponds to the DTE's "receptor", but not always.
+
+"""
 import dataclasses
 from dataclasses import field as dc_field
 from datetime import date
@@ -228,6 +245,40 @@ class DteDataL1(DteDataL0):
             raise TypeError("Inappropriate type of 'monto_total'.")
 
         validate_dte_monto_total(self.monto_total)
+
+    @property
+    def vendedor_rut(self) -> Rut:
+        """
+        Return the RUT of the "vendedor".
+
+        :raises ValueError:
+        """
+        if self.tipo_dte.emisor_is_vendedor:
+            result = self.emisor_rut
+        elif self.tipo_dte.receptor_is_vendedor:
+            result = self.receptor_rut
+        else:
+            raise ValueError(
+                "Concept \"vendedor\" does not apply for this 'tipo_dte'.", self.tipo_dte)
+
+        return result
+
+    @property
+    def deudor_rut(self) -> Rut:
+        """
+        Return the RUT of the "deudor".
+
+        :raises ValueError:
+        """
+        if self.tipo_dte.emisor_is_vendedor:
+            result = self.receptor_rut
+        elif self.tipo_dte.receptor_is_vendedor:
+            result = self.emisor_rut
+        else:
+            raise ValueError(
+                "Concept \"deudor\" does not apply for this 'tipo_dte'.", self.tipo_dte)
+
+        return result
 
 
 @dataclasses.dataclass(frozen=True)

--- a/cl_sii/dte/data_models.py
+++ b/cl_sii/dte/data_models.py
@@ -229,10 +229,6 @@ class DteDataL1(DteDataL0):
 
         validate_dte_monto_total(self.monto_total)
 
-    @property
-    def natural_key(self) -> DteNaturalKey:
-        return DteNaturalKey(emisor_rut=self.emisor_rut, tipo_dte=self.tipo_dte, folio=self.folio)
-
 
 @dataclasses.dataclass(frozen=True)
 class DteDataL2(DteDataL1):

--- a/tests/test_dte_constants.py
+++ b/tests/test_dte_constants.py
@@ -1,0 +1,128 @@
+import unittest
+
+from cl_sii.dte import constants  # noqa: F401
+from cl_sii.dte.constants import TipoDteEnum
+
+
+class TipoDteEnumTest(unittest.TestCase):
+
+    def test_members(self):
+        self.assertSetEqual(
+            {x for x in TipoDteEnum},
+            {
+                TipoDteEnum.FACTURA_ELECTRONICA,
+                TipoDteEnum.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA,
+                TipoDteEnum.FACTURA_COMPRA_ELECTRONICA,
+                TipoDteEnum.GUIA_DESPACHO_ELECTRONICA,
+                TipoDteEnum.NOTA_DEBITO_ELECTRONICA,
+                TipoDteEnum.NOTA_CREDITO_ELECTRONICA,
+            }
+        )
+
+    def test_FACTURA_ELECTRONICA(self):
+        value = TipoDteEnum.FACTURA_ELECTRONICA
+
+        self.assertEqual(value.name, 'FACTURA_ELECTRONICA')
+        self.assertEqual(value.value, 33)
+
+        assertions = [
+            (value.is_factura, True),
+            (value.is_factura_venta, True),
+            (value.is_factura_compra, False),
+            (value.is_nota, False),
+            (value.emisor_is_vendedor, True),
+            (value.receptor_is_vendedor, False),
+        ]
+
+        for (result, expected) in assertions:
+            self.assertEqual(result, expected)
+
+    def test_FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA(self):
+        value = TipoDteEnum.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA
+
+        self.assertEqual(value.name, 'FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA')
+        self.assertEqual(value.value, 34)
+
+        assertions = [
+            (value.is_factura, True),
+            (value.is_factura_venta, True),
+            (value.is_factura_compra, False),
+            (value.is_nota, False),
+            (value.emisor_is_vendedor, True),
+            (value.receptor_is_vendedor, False),
+        ]
+
+        for (result, expected) in assertions:
+            self.assertTrue(result is expected)
+
+    def test_FACTURA_COMPRA_ELECTRONICA(self):
+        value = TipoDteEnum.FACTURA_COMPRA_ELECTRONICA
+
+        self.assertEqual(value.name, 'FACTURA_COMPRA_ELECTRONICA')
+        self.assertEqual(value.value, 46)
+
+        assertions = [
+            (value.is_factura, True),
+            (value.is_factura_venta, False),
+            (value.is_factura_compra, True),
+            (value.is_nota, False),
+            (value.emisor_is_vendedor, False),
+            (value.receptor_is_vendedor, True),
+        ]
+
+        for (result, expected) in assertions:
+            self.assertTrue(result is expected)
+
+    def test_GUIA_DESPACHO_ELECTRONICA(self):
+        value = TipoDteEnum.GUIA_DESPACHO_ELECTRONICA
+
+        self.assertEqual(value.name, 'GUIA_DESPACHO_ELECTRONICA')
+        self.assertEqual(value.value, 52)
+
+        assertions = [
+            (value.is_factura, False),
+            (value.is_factura_venta, False),
+            (value.is_factura_compra, False),
+            (value.is_nota, False),
+            (value.emisor_is_vendedor, False),
+            (value.receptor_is_vendedor, False),
+        ]
+
+        for (result, expected) in assertions:
+            self.assertTrue(result is expected)
+
+    def test_NOTA_DEBITO_ELECTRONICA(self):
+        value = TipoDteEnum.NOTA_DEBITO_ELECTRONICA
+
+        self.assertEqual(value.name, 'NOTA_DEBITO_ELECTRONICA')
+        self.assertEqual(value.value, 56)
+
+        assertions = [
+            (value.is_factura, False),
+            (value.is_factura_venta, False),
+            (value.is_factura_compra, False),
+            (value.is_nota, True),
+            (value.emisor_is_vendedor, False),
+            (value.receptor_is_vendedor, False),
+        ]
+
+        for (result, expected) in assertions:
+            self.assertTrue(result is expected)
+
+    def test_NOTA_CREDITO_ELECTRONICA(self):
+        value = TipoDteEnum.NOTA_CREDITO_ELECTRONICA
+
+        self.assertEqual(value.name, 'NOTA_CREDITO_ELECTRONICA')
+        self.assertEqual(value.value, 61)
+
+        assertions = [
+            (value.is_factura, False),
+            (value.is_factura_venta, False),
+            (value.is_factura_compra, False),
+            (value.is_nota, True),
+            (value.emisor_is_vendedor, False),
+            (value.receptor_is_vendedor, False),
+        ]
+
+        for (result, expected) in assertions:
+            self.assertTrue(result is expected)

--- a/tests/test_dte_data_models.py
+++ b/tests/test_dte_data_models.py
@@ -1,3 +1,4 @@
+import dataclasses
 import unittest
 from datetime import date
 
@@ -102,6 +103,36 @@ class DteDataL1Test(unittest.TestCase):
                 receptor_rut=Rut('96790240-3'),
                 monto_total=2996301,
             ))
+
+    def test_vendedor_rut_deudor_rut(self) -> None:
+        emisor_rut = self.dte_l1_1.emisor_rut
+        receptor_rut = self.dte_l1_1.receptor_rut
+        dte_factura_venta = dataclasses.replace(
+            self.dte_l1_1, tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA)
+        dte_factura_venta_exenta = dataclasses.replace(
+            self.dte_l1_1, tipo_dte=TipoDteEnum.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA)
+        dte_factura_compra = dataclasses.replace(
+            self.dte_l1_1, tipo_dte=TipoDteEnum.FACTURA_COMPRA_ELECTRONICA)
+        dte_nota_credito = dataclasses.replace(
+            self.dte_l1_1, tipo_dte=TipoDteEnum.NOTA_CREDITO_ELECTRONICA)
+
+        self.assertEqual(dte_factura_venta.vendedor_rut, emisor_rut)
+        self.assertEqual(dte_factura_venta_exenta.vendedor_rut, emisor_rut)
+        self.assertEqual(dte_factura_compra.vendedor_rut, receptor_rut)
+        with self.assertRaises(ValueError) as cm:
+            self.assertIsNone(dte_nota_credito.vendedor_rut)
+        self.assertEqual(
+            cm.exception.args,
+            ("Concept \"vendedor\" does not apply for this 'tipo_dte'.", dte_nota_credito.tipo_dte))
+
+        self.assertEqual(dte_factura_venta.deudor_rut, receptor_rut)
+        self.assertEqual(dte_factura_venta_exenta.deudor_rut, receptor_rut)
+        self.assertEqual(dte_factura_compra.deudor_rut, emisor_rut)
+        with self.assertRaises(ValueError) as cm:
+            self.assertIsNone(dte_nota_credito.deudor_rut)
+        self.assertEqual(
+            cm.exception.args,
+            ("Concept \"deudor\" does not apply for this 'tipo_dte'.", dte_nota_credito.tipo_dte))
 
 
 class DteDataL2Test(unittest.TestCase):

--- a/tests/test_dte_data_models.py
+++ b/tests/test_dte_data_models.py
@@ -1,6 +1,6 @@
 import dataclasses
 import unittest
-from datetime import date
+from datetime import date, datetime
 
 from cl_sii.rut import Rut  # noqa: F401
 
@@ -150,6 +150,12 @@ class DteDataL2Test(unittest.TestCase):
             emisor_razon_social='INGENIERIA ENACON SPA',
             receptor_razon_social='MINERA LOS PELAMBRES',
             fecha_vencimiento_date=None,
+            firma_documento_dt_naive=datetime(2019, 4, 1, 1, 36, 40),
+            signature_value_base64=None,
+            signature_x509_cert_base64=None,
+            emisor_giro='Ingenieria y Construccion',
+            emisor_email='hello@example.com',
+            receptor_email=None,
         )
 
     def test_init_fail(self) -> None:
@@ -169,6 +175,12 @@ class DteDataL2Test(unittest.TestCase):
                 emisor_razon_social='INGENIERIA ENACON SPA',
                 receptor_razon_social='MINERA LOS PELAMBRES',
                 fecha_vencimiento_date=None,
+                firma_documento_dt_naive=datetime(2019, 4, 1, 1, 36, 40),
+                signature_value_base64=None,
+                signature_x509_cert_base64=None,
+                emisor_giro='Ingenieria y Construccion',
+                emisor_email='hello@example.com',
+                receptor_email=None,
             ))
 
 

--- a/tests/test_dte_data_models.py
+++ b/tests/test_dte_data_models.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import date
 
 from cl_sii.rut import Rut  # noqa: F401
 
@@ -11,38 +12,145 @@ from cl_sii.dte.data_models import (  # noqa: F401
 
 class DteNaturalKeyTest(unittest.TestCase):
 
-    # TODO: implement!
-    pass
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.dte_nk_1 = DteNaturalKey(
+            emisor_rut=Rut('76354771-K'),
+            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            folio=170,
+        )
+
+    def test_init_fail(self) -> None:
+        # TODO: implement for 'DteNaturalKey()'
+        pass
+
+    def test_as_dict(self) -> None:
+        self.assertDictEqual(
+            self.dte_nk_1.as_dict(),
+            dict(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+            )
+        )
+
+    def test_slug(self) -> None:
+        self.assertEqual(self.dte_nk_1.slug, '76354771-K--33--170')
 
 
 class DteDataL0Test(unittest.TestCase):
 
-    # TODO: implement!
-    pass
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.dte_l0_1 = DteDataL0(
+            emisor_rut=Rut('76354771-K'),
+            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            folio=170,
+        )
+
+    def test_init_fail(self) -> None:
+        # TODO: implement for 'DteDataL0()'
+        pass
+
+    def test_as_dict(self) -> None:
+        self.assertDictEqual(
+            self.dte_l0_1.as_dict(),
+            dict(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+            ))
+
+    def test_natural_key(self) -> None:
+        self.assertEqual(
+            self.dte_l0_1.natural_key,
+            DteNaturalKey(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+            ))
 
 
 class DteDataL1Test(unittest.TestCase):
 
-    # TODO: implement!
-    pass
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.dte_l1_1 = DteDataL1(
+            emisor_rut=Rut('76354771-K'),
+            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            folio=170,
+            fecha_emision_date=date(2019, 4, 1),
+            receptor_rut=Rut('96790240-3'),
+            monto_total=2996301,
+        )
+
+    def test_init_fail(self) -> None:
+        # TODO: implement for 'DteDataL1()'
+        pass
+
+    def test_as_dict(self) -> None:
+        self.assertDictEqual(
+            self.dte_l1_1.as_dict(),
+            dict(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+                fecha_emision_date=date(2019, 4, 1),
+                receptor_rut=Rut('96790240-3'),
+                monto_total=2996301,
+            ))
 
 
 class DteDataL2Test(unittest.TestCase):
 
-    # TODO: implement!
-    pass
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.dte_l2_1 = DteDataL2(
+            emisor_rut=Rut('76354771-K'),
+            tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+            folio=170,
+            fecha_emision_date=date(2019, 4, 1),
+            receptor_rut=Rut('96790240-3'),
+            monto_total=2996301,
+            emisor_razon_social='INGENIERIA ENACON SPA',
+            receptor_razon_social='MINERA LOS PELAMBRES',
+            fecha_vencimiento_date=None,
+        )
+
+    def test_init_fail(self) -> None:
+        # TODO: implement for 'DteDataL2()'
+        pass
+
+    def test_as_dict(self) -> None:
+        self.assertDictEqual(
+            self.dte_l2_1.as_dict(),
+            dict(
+                emisor_rut=Rut('76354771-K'),
+                tipo_dte=TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=170,
+                fecha_emision_date=date(2019, 4, 1),
+                receptor_rut=Rut('96790240-3'),
+                monto_total=2996301,
+                emisor_razon_social='INGENIERIA ENACON SPA',
+                receptor_razon_social='MINERA LOS PELAMBRES',
+                fecha_vencimiento_date=None,
+            ))
 
 
 class FunctionsTest(unittest.TestCase):
 
     def test_validate_contribuyente_razon_social(self) -> None:
-        # TODO: implement!
+        # TODO: implement for 'validate_contribuyente_razon_social'
         pass
 
     def test_validate_dte_folio(self) -> None:
-        # TODO: implement!
+        # TODO: implement for 'validate_dte_folio'
         pass
 
     def test_validate_dte_monto_total(self) -> None:
-        # TODO: implement!
+        # TODO: implement for 'validate_dte_monto_total'
         pass

--- a/tests/test_dte_parse.py
+++ b/tests/test_dte_parse.py
@@ -16,7 +16,8 @@ from cl_sii.dte.parse import (  # noqa: F401
 from .utils import read_test_file_bytes
 
 
-_TEST_DTE_NEEDS_CLEAN_FILE_PATH = 'test_data/sii-dte/DTE--76354771-K--33--170.xml'
+_TEST_DTE_NEEDS_CLEAN_1_FILE_PATH = 'test_data/sii-dte/DTE--76354771-K--33--170.xml'
+_TEST_DTE_NEEDS_CLEAN_2_FILE_PATH = 'test_data/sii-dte/DTE--76399752-9--33--25568.xml'
 
 
 class OthersTest(unittest.TestCase):
@@ -25,10 +26,10 @@ class OthersTest(unittest.TestCase):
         # TODO: implement
         pass
 
-    def test_integration_ok(self) -> None:
+    def test_integration_ok_1(self) -> None:
         # TODO: split in separate tests, with more coverage.
 
-        dte_bad_xml_file_path = _TEST_DTE_NEEDS_CLEAN_FILE_PATH
+        dte_bad_xml_file_path = _TEST_DTE_NEEDS_CLEAN_1_FILE_PATH
 
         file_bytes = read_test_file_bytes(dte_bad_xml_file_path)
         xml_doc = xml_utils.parse_untrusted_xml(file_bytes)
@@ -111,6 +112,105 @@ class OthersTest(unittest.TestCase):
             b'-<DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />',
             b'+<DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>',
             b' <DigestValue>ij2Qn6xOc2eRx3hwyO/GrzptoBk=</DigestValue>',
+            b' </Reference>',
+            b' </SignedInfo>',
+        )
+
+        file_bytes_diff_gen = difflib.diff_bytes(
+            dfunc=difflib.unified_diff,
+            a=file_bytes.splitlines(),
+            b=file_bytes_rewritten.splitlines())
+        self.assertSequenceEqual(
+            [diff_line for diff_line in file_bytes_diff_gen],
+            expected_file_bytes_diff
+        )
+
+    def test_integration_ok_2(self) -> None:
+        # TODO: split in separate tests, with more coverage.
+
+        dte_bad_xml_file_path = _TEST_DTE_NEEDS_CLEAN_2_FILE_PATH
+
+        file_bytes = read_test_file_bytes(dte_bad_xml_file_path)
+        xml_doc = xml_utils.parse_untrusted_xml(file_bytes)
+
+        self.assertEqual(
+            xml_doc.getroottree().getroot().tag,
+            'DTE')
+
+        with self.assertRaises(xml_utils.XmlSchemaDocValidationError) as cm:
+            validate_dte_xml(xml_doc)
+        self.assertSequenceEqual(
+            cm.exception.args,
+            ("Element 'DTE': No matching global declaration available for the validation root., "
+             "line 2", )
+        )
+        # This would raise:
+        # parse_dte_xml(xml_doc)
+
+        xml_doc_cleaned, modified = clean_dte_xml(
+            xml_doc,
+            set_missing_xmlns=True,
+            remove_doc_personalizado=True,
+        )
+        self.assertTrue(modified)
+
+        # This will not raise.
+        validate_dte_xml(xml_doc_cleaned)
+
+        self.assertEqual(
+            xml_doc_cleaned.getroottree().getroot().tag,
+            '{%s}DTE' % DTE_XMLNS)
+
+        f = io.BytesIO()
+        xml_utils.write_xml_doc(xml_doc_cleaned, f)
+        file_bytes_rewritten = f.getvalue()
+        del f
+
+        xml_doc_rewritten = xml_utils.parse_untrusted_xml(file_bytes_rewritten)
+        validate_dte_xml(xml_doc_rewritten)
+        parsed_dte_rewritten = parse_dte_xml(xml_doc_cleaned)
+
+        self.assertDictEqual(
+            dict(parsed_dte_rewritten.as_dict()),
+            dict(
+                emisor_rut=Rut('76399752-9'),
+                tipo_dte=cl_sii.dte.constants.TipoDteEnum.FACTURA_ELECTRONICA,
+                folio=25568,
+                fecha_emision_date=date(2019, 3, 29),
+                receptor_rut=Rut('96874030-K'),
+                monto_total=230992,
+                emisor_razon_social='COMERCIALIZADORA INNOVA MOBEL SPA',
+                receptor_razon_social='EMPRESAS LA POLAR S.A.',
+                fecha_vencimiento_date=None,
+            ))
+
+        expected_file_bytes_diff = (
+            b'--- \n',
+            b'+++ \n',
+            b'@@ -1,5 +1,5 @@\n',
+            b'-<?xml version="1.0" encoding="ISO-8859-1"?>',
+            b'-<DTE version="1.0">',
+            b"+<?xml version='1.0' encoding='ISO-8859-1'?>",
+            b'+<DTE xmlns="http://www.sii.cl/SiiDte" version="1.0">',
+            b'   <!-- O Win32 Chrome 73 central VERSION: v20190227 -->',
+            b' <Documento ID="MiPE76399752-6048">',
+            b'     <Encabezado>',
+            b'@@ -64,13 +64,13 @@\n',
+            b'   </Documento>',
+            b' <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">',
+            b' <SignedInfo>',
+            b'-<CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />',  # noqa: E501
+            b'-<SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1" />',
+            b'+<CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>',  # noqa: E501
+            b'+<SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>',
+            b' <Reference URI="#MiPE76399752-6048">',
+            b' <Transforms>',
+            b'-<Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />',
+            b'+<Transform Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>',
+            b' </Transforms>',
+            b'-<DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" />',
+            b'+<DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>',
+            b' <DigestValue>tk/D3mfO/KtdWyFXYZHe7dtYijg=</DigestValue>',
             b' </Reference>',
             b' </SignedInfo>',
         )

--- a/tests/test_dte_parse.py
+++ b/tests/test_dte_parse.py
@@ -1,7 +1,7 @@
 import difflib
 import io
 import unittest
-from datetime import date
+from datetime import date, datetime
 
 import cl_sii.dte.constants
 from cl_sii.libs import xml_utils
@@ -18,6 +18,76 @@ from .utils import read_test_file_bytes
 
 _TEST_DTE_NEEDS_CLEAN_1_FILE_PATH = 'test_data/sii-dte/DTE--76354771-K--33--170.xml'
 _TEST_DTE_NEEDS_CLEAN_2_FILE_PATH = 'test_data/sii-dte/DTE--76399752-9--33--25568.xml'
+_TEST_DTE_1_FILE_PATH = _TEST_DTE_NEEDS_CLEAN_1_FILE_PATH
+_TEST_DTE_2_FILE_PATH = _TEST_DTE_NEEDS_CLEAN_2_FILE_PATH
+_TEST_DTE_1_SIGNATURE_VALUE = (
+    'fsYP5p/lNfofAz8POShrJjqXdBTNNtvv4/TWCxbvwTIAXr7BLrlvX3C/Hpfo4viqaxSu1OGFgPnk\n'
+    'ddDIFwj/ZsVdbdB+MhpKkyha83RxhJpYBVBY3c+y9J6oMfdIdMAYXhEkFw8w63KHyhdf2E9dnbKi\n'
+    'wqSxDcYjTT6vXsLPrZk=')
+_TEST_DTE_2_SIGNATURE_VALUE = (
+    'wwOMQuFqa6c5gzYSJ5PWfo0OiAf+yNcJK6wx4xJ3VNehlAcMrUB2q+rK/DDhCvjxAoX4NxBACiFD\n'
+    'MrTMIfvxrwXjLd1oX37lSFOtsWX6JxL0SV+tLF7qvWCu1Yzw8ypUf7GDkbymJkoTYDF9JFF8kYU4\n'
+    'FdU2wttiwne9XH8QFHgXsocKP/aygwiOeGqiNX9o/O5XS2GWpt+KM20jrvtYn7UFMED/3aPacCb1\n'
+    'GABizr8mlVEZggZgJunMDChpFQyEigSXMK5I737Ac8D2bw7WB47Wj1WBL3sCFRDlXUXtnMvChBVp\n'
+    '0HRUXYuKHyfpCzqIBXygYrIZexxXgOSnKu/yGg==')
+_TEST_DTE_1_X509_CERT = (
+    'MIIGVDCCBTygAwIBAgIKMUWmvgAAAAjUHTANBgkqhkiG9w0BAQUFADCB0jELMAkGA1UEBhMCQ0wx\n'
+    'HTAbBgNVBAgTFFJlZ2lvbiBNZXRyb3BvbGl0YW5hMREwDwYDVQQHEwhTYW50aWFnbzEUMBIGA1UE\n'
+    'ChMLRS1DRVJUQ0hJTEUxIDAeBgNVBAsTF0F1dG9yaWRhZCBDZXJ0aWZpY2Fkb3JhMTAwLgYDVQQD\n'
+    'EydFLUNFUlRDSElMRSBDQSBGSVJNQSBFTEVDVFJPTklDQSBTSU1QTEUxJzAlBgkqhkiG9w0BCQEW\n'
+    'GHNjbGllbnRlc0BlLWNlcnRjaGlsZS5jbDAeFw0xNzA5MDQyMTExMTJaFw0yMDA5MDMyMTExMTJa\n'
+    'MIHXMQswCQYDVQQGEwJDTDEUMBIGA1UECBMLVkFMUEFSQUlTTyAxETAPBgNVBAcTCFF1aWxsb3Rh\n'
+    'MS8wLQYDVQQKEyZTZXJ2aWNpb3MgQm9uaWxsYSB5IExvcGV6IHkgQ2lhLiBMdGRhLjEkMCIGA1UE\n'
+    'CwwbSW5nZW5pZXLDrWEgeSBDb25zdHJ1Y2Npw7NuMSMwIQYDVQQDExpSYW1vbiBodW1iZXJ0byBM\n'
+    'b3BleiAgSmFyYTEjMCEGCSqGSIb3DQEJARYUZW5hY29ubHRkYUBnbWFpbC5jb20wgZ8wDQYJKoZI\n'
+    'hvcNAQEBBQADgY0AMIGJAoGBAKQeAbNDqfi9M2v86RUGAYgq1ZSDioFC6OLr0SwiOaYnLsSOl+Kx\n'
+    'O394PVwSGa6rZk1ErIZonyi15fU/0nHZLi8iHLB49EB5G3tCwh0s8NfqR9ck0/3Z+TXhVUdiJyJC\n'
+    '/z8x5I5lSUfzNEedJRidVvp6jVGr7P/SfoEfQQTLP3mBAgMBAAGjggKnMIICozA9BgkrBgEEAYI3\n'
+    'FQcEMDAuBiYrBgEEAYI3FQiC3IMvhZOMZoXVnReC4twnge/sPGGBy54UhqiCWAIBZAIBBDAdBgNV\n'
+    'HQ4EFgQU1dVHhF0UVe7RXIz4cjl3/Vew+qowCwYDVR0PBAQDAgTwMB8GA1UdIwQYMBaAFHjhPp/S\n'
+    'ErN6PI3NMA5Ts0MpB7NVMD4GA1UdHwQ3MDUwM6AxoC+GLWh0dHA6Ly9jcmwuZS1jZXJ0Y2hpbGUu\n'
+    'Y2wvZWNlcnRjaGlsZWNhRkVTLmNybDA6BggrBgEFBQcBAQQuMCwwKgYIKwYBBQUHMAGGHmh0dHA6\n'
+    'Ly9vY3NwLmVjZXJ0Y2hpbGUuY2wvb2NzcDAjBgNVHREEHDAaoBgGCCsGAQQBwQEBoAwWCjEzMTg1\n'
+    'MDk1LTYwIwYDVR0SBBwwGqAYBggrBgEEAcEBAqAMFgo5NjkyODE4MC01MIIBTQYDVR0gBIIBRDCC\n'
+    'AUAwggE8BggrBgEEAcNSBTCCAS4wLQYIKwYBBQUHAgEWIWh0dHA6Ly93d3cuZS1jZXJ0Y2hpbGUu\n'
+    'Y2wvQ1BTLmh0bTCB/AYIKwYBBQUHAgIwge8egewAQwBlAHIAdABpAGYAaQBjAGEAZABvACAARgBp\n'
+    'AHIAbQBhACAAUwBpAG0AcABsAGUALgAgAEgAYQAgAHMAaQBkAG8AIAB2AGEAbABpAGQAYQBkAG8A\n'
+    'IABlAG4AIABmAG8AcgBtAGEAIABwAHIAZQBzAGUAbgBjAGkAYQBsACwAIABxAHUAZQBkAGEAbgBk\n'
+    'AG8AIABoAGEAYgBpAGwAaQB0AGEAZABvACAAZQBsACAAQwBlAHIAdABpAGYAaQBjAGEAZABvACAA\n'
+    'cABhAHIAYQAgAHUAcwBvACAAdAByAGkAYgB1AHQAYQByAGkAbzANBgkqhkiG9w0BAQUFAAOCAQEA\n'
+    'mxtPpXWslwI0+uJbyuS9s/S3/Vs0imn758xMU8t4BHUd+OlMdNAMQI1G2+q/OugdLQ/a9Sg3clKD\n'
+    'qXR4lHGl8d/Yq4yoJzDD3Ceez8qenY3JwGUhPzw9oDpg4mXWvxQDXSFeW/u/BgdadhfGnpwx61Un\n'
+    '+/fU24ZgU1dDJ4GKj5oIPHUIjmoSBhnstEhIr6GJWSTcDKTyzRdqBlaVhenH2Qs6Mw6FrOvRPuud\n'
+    'B7lo1+OgxMb/Gjyu6XnEaPu7Vq4XlLYMoCD2xrV7WEADaDTm7KcNLczVAYqWSF1WUqYSxmPoQDFY\n'
+    '+kMTThJyCXBlE0NADInrkwWgLLygkKI7zXkwaw==')
+_TEST_DTE_2_X509_CERT = (
+    'MIIF/zCCBOegAwIBAgICMhQwDQYJKoZIhvcNAQELBQAwgaYxCzAJBgNVBAYTAkNMMRgwFgYDVQQK\n'
+    'Ew9BY2VwdGEuY29tIFMuQS4xSDBGBgNVBAMTP0FjZXB0YS5jb20gQXV0b3JpZGFkIENlcnRpZmlj\n'
+    'YWRvcmEgQ2xhc2UgMiBQZXJzb25hIE5hdHVyYWwgLSBHNDEeMBwGCSqGSIb3DQEJARYPaW5mb0Bh\n'
+    'Y2VwdGEuY29tMRMwEQYDVQQFEwo5NjkxOTA1MC04MB4XDTE3MDEwNjE0MDI1NFoXDTIwMDEwNjE0\n'
+    'MDI1NFowgY8xCzAJBgNVBAYTAkNMMRgwFgYDVQQMEw9QRVJTT05BIE5BVFVSQUwxIzAhBgNVBAMT\n'
+    'GkdJQU5JTkEgQkVMRU4gRElBWiBVUlJVVElBMSwwKgYJKoZIhvcNAQkBFh1kYW5pZWwuYXJhdmVu\n'
+    'YUBpbm5vdmFtb2JlbC5jbDETMBEGA1UEBRMKMTY0Nzc3NTItOTCCASIwDQYJKoZIhvcNAQEBBQAD\n'
+    'ggEPADCCAQoCggEBANLQYWfXROtuPiyInyROQc+DZ2LdpvaShxU6iU2xB+CQs74HZ+oS1BINzmL1\n'
+    'g9oY7hHvT+/H+hucOlN7xomH/UuDikjoySjhbH3xBMzh6qWHvDqcfTswYuHES2hO9keTzwytyUIP\n'
+    'HTctMNJ32mIQ/fGU8H+Qf7adtV+A7k3jXgvCu3DQ5ceeR1xUyDbTXIWJDtg215sa3YSkto3iPNSh\n'
+    'qiKeGfsh/qUEaH3oK/Tf0lOG/CG/bnvLdubacc9o7B5QS6JF5ILMffCEuzBrxyMZLhBQYm1ah6dS\n'
+    'EbCsDNkc6sQMHLYg/0qG1N+cILXVyusGGCCEDTfmXb/AI4rEKaJt0XMCAwEAAaOCAkowggJGMB8G\n'
+    'A1UdIwQYMBaAFGWlqz4/yLZRbRF+X8MKB+ZDoAi2MB0GA1UdDgQWBBSHoSD4nd2UJuwzmJnJud0L\n'
+    'WSO+MzALBgNVHQ8EBAMCBPAwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMEMBEGCWCGSAGG\n'
+    '+EIBAQQEAwIFoDB1BgNVHSAEbjBsMGoGCCsGAQQBtWsCMF4wMQYIKwYBBQUHAgEWJWh0dHBzOi8v\n'
+    'YWNnNC5hY2VwdGEuY29tL0NQUy1BY2VwdGFjb20wKQYIKwYBBQUHAgIwHTAWFg9BY2VwdGEuY29t\n'
+    'IFMuQS4wAwIBCRoDVEJEMFoGA1UdEgRTMFGgGAYIKwYBBAHBAQKgDBYKOTY5MTkwNTAtOKAkBggr\n'
+    'BgEFBQcIA6AYMBYMCjk2OTE5MDUwLTgGCCsGAQQBwQECgQ9pbmZvQGFjZXB0YS5jb20waAYDVR0R\n'
+    'BGEwX6AYBggrBgEEAcEBAaAMFgoxNjQ3Nzc1Mi05oCQGCCsGAQUFBwgDoBgwFgwKMTY0Nzc3NTIt\n'
+    'OQYIKwYBBAHBAQKBHWRhbmllbC5hcmF2ZW5hQGlubm92YW1vYmVsLmNsMEcGCCsGAQUFBwEBBDsw\n'
+    'OTA3BggrBgEFBQcwAYYraHR0cHM6Ly9hY2c0LmFjZXB0YS5jb20vYWNnNC9vY3NwL0NsYXNlMi1H\n'
+    'NDA/BgNVHR8EODA2MDSgMqAwhi5odHRwczovL2FjZzQuYWNlcHRhLmNvbS9hY2c0L2NybC9DbGFz\n'
+    'ZTItRzQuY3JsMA0GCSqGSIb3DQEBCwUAA4IBAQCx+mdIdIu1QQf6mnFDCYfcyhU5t5iKV+8Pr8LV\n'
+    'WZdlwGmKRbzhqYKZ8oo5Bfmto105z7JYJIFyZiny/8sb9IcoPLNG/6LtWZZFmHkZabC9sUEjSxU/\n'
+    'w8w2VMhrCILonVjnhLX8VHNMkc3Xy17JgvUAIcor2MHfNxn0lyEM3EZdROkgDxwuWfS388mqg8KB\n'
+    'B/QNi7AB5U9kB7M5wfGr2lYAvkzlTmHlcBFI2fI6odZlfzLnyKN/ow9mow4Z4ngKuhlTpTUVrACg\n'
+    'jhl1gijANMhS1SwNpPgOLlf54KbXTQxWrrwt9mEMZBH7w6imtxJGzNWPjPcykRB7YQxhrHkfzmrw')
 
 
 class OthersTest(unittest.TestCase):
@@ -83,6 +153,12 @@ class OthersTest(unittest.TestCase):
                 emisor_razon_social='INGENIERIA ENACON SPA',
                 receptor_razon_social='MINERA LOS PELAMBRES',
                 fecha_vencimiento_date=None,
+                firma_documento_dt_naive=datetime(2019, 4, 1, 1, 36, 40),
+                signature_value_base64=_TEST_DTE_1_SIGNATURE_VALUE,
+                signature_x509_cert_base64=_TEST_DTE_1_X509_CERT,
+                emisor_giro='Ingenieria y Construccion',
+                emisor_email='ENACONLTDA@GMAIL.COM',
+                receptor_email=None,
             ))
 
         expected_file_bytes_diff = (
@@ -182,6 +258,12 @@ class OthersTest(unittest.TestCase):
                 emisor_razon_social='COMERCIALIZADORA INNOVA MOBEL SPA',
                 receptor_razon_social='EMPRESAS LA POLAR S.A.',
                 fecha_vencimiento_date=None,
+                firma_documento_dt_naive=datetime(2019, 3, 28, 13, 59, 52),
+                signature_value_base64=_TEST_DTE_2_SIGNATURE_VALUE,
+                signature_x509_cert_base64=_TEST_DTE_2_X509_CERT,
+                emisor_giro='COMERCIALIZACION DE PRODUCTOS PARA EL HOGAR',
+                emisor_email='ANGEL.PEZO@APCASESORIAS.CL',
+                receptor_email=None,
             ))
 
         expected_file_bytes_diff = (


### PR DESCRIPTION
## Summary

- Add fields to `data_models.DteDataL2`.
- Add properties to `data_models.DteDataL1`.
- Re-implement, improve and augment `parse.parse_dte_xml`.
- Add helper properties to `TipoDteEnum`.
- Implement missing tests for `data_models`.
- Implement missing tests for `constants`.


## Detail


### `data_models`

- Add fields to `DteDataL2`:
    - `firma_documento_dt_naive`
    - `signature_value_base64`
    - `signature_x509_cert_base64`
    - `emisor_giro`
    - `emisor_email`
    - `receptor_email`
- Add properties to `DteDataL1`:
    - `vendedor_rut`
    - `deudor_rut`
- Remove redundant property `DteDataL1.natural_key`
- Implement missing tests (and add some test stubs).


### `parse`

- Re-implement, improve and augment `parse_dte_xml`.
- Improve tests.
- Fix poor usage of 'lxml'.


### `constants`

- Add helper properties to `TipoDteEnum`.
- Improve docstrings and comments a little.
- Implement tests.
