### PR TITLE
docs: Fix `bumpversion` command

### DIFF
--- a/docs/project-maintenance.rst
+++ b/docs/project-maintenance.rst
@@ -46,7 +46,7 @@ Add new entry to changelog including the changes summary (remember to format as 
 Either of the following alternatives::
 
     bumpversion major|minor|patch
-    bumpversion --new-version 'X.Y.Z'
+    bumpversion --new-version 'X.Y.Z' part  # 'part' is a dummy argument.
 
 Push commit ``abcd1234`` and tag ``vX.Y.Z`` automatically created by ``bumpversion``::
 


### PR DESCRIPTION
The command `bumpversion --new-version 'X.Y.Z'` doesn't work.
It returns the error `the following arguments are required: part`.

The `part` argument doesn't matter when a complete new version number
is specified, but `bumpversion` still complains if that parameter is
missing.

This change fixes the error by adding a dummy `part` argument.

Ref:
- [Slack](https://fynpal-hq.slack.com/archives/CFGURBDBK/p1557152981014100?thread_ts=1556809374.013500&cid=CFGURBDBK)
- [Slack](https://fynpal-hq.slack.com/archives/CFGURBDBK/p1557154032014300?thread_ts=1556809374.013500&cid=CFGURBDBK)
- [Slack](https://fynpal-hq.slack.com/archives/CFGURBDBK/p1557154124014600?thread_ts=1556809374.013500&cid=CFGURBDBK)