### PR TITLE
rcv: add data models, constants and more

### DIFF
--- a/cl_sii/extras/mm_fields.py
+++ b/cl_sii/extras/mm_fields.py
@@ -14,6 +14,7 @@ from typing import Optional
 import marshmallow.fields
 
 from cl_sii.dte.constants import TipoDteEnum
+from cl_sii.rcv.constants import RcvTipoDocto
 from cl_sii.rut import Rut
 
 
@@ -115,5 +116,58 @@ class TipoDteField(marshmallow.fields.Field):
                 validated = TipoDteEnum(value)  # type: ignore
             except ValueError:
                 # TipoDteEnum('x') raises 'ValueError', not 'TypeError'
+                self.fail('invalid')
+        return validated
+
+
+class RcvTipoDoctoField(marshmallow.fields.Field):
+
+    """
+    Marshmallow field for RCV's "tipo documento".
+
+    Data types:
+    * native/primitive/internal/deserialized: :class:`RcvTipoDocto`
+    * representation/serialized: int, same as for Marshmallow field
+      :class:`marshmallow.fields.Integer`
+
+    The field performs some input value cleaning when it is an str;
+    for example ``'  33 \t '`` is allowed and the resulting value
+    is ``RcvTipoDocto(33)``.
+
+    Implementation almost identical to :class:`TipoDteField`.
+
+    """
+
+    default_error_messages = {
+        'invalid': "Not a valid RCV's Tipo de Documento."
+    }
+
+    def _serialize(self, value: Optional[object], attr: str, obj: object) -> Optional[int]:
+        validated: Optional[RcvTipoDocto] = self._validated(value)
+        return validated.value if validated is not None else None
+
+    def _deserialize(self, value: object, attr: str, data: dict) -> Optional[RcvTipoDocto]:
+        return self._validated(value)
+
+    def _validated(self, value: Optional[object]) -> Optional[RcvTipoDocto]:
+        if value is None or isinstance(value, RcvTipoDocto):
+            validated = value
+        else:
+            if isinstance(value, bool):
+                # is value is bool, `isinstance(value, int)` is True and `int(value)` works!
+                self.fail('type')
+            try:
+                value = int(value)  # type: ignore
+            except ValueError:
+                # `int('x')` raises 'ValueError', not 'TypeError'
+                self.fail('type')
+            except TypeError:
+                # `int(date(2018, 10, 10))` raises 'TypeError', unlike `int('x')`
+                self.fail('type')
+
+            try:
+                validated = RcvTipoDocto(value)  # type: ignore
+            except ValueError:
+                # RcvTipoDocto('x') raises 'ValueError', not 'TypeError'
                 self.fail('invalid')
         return validated

--- a/cl_sii/rcv/__init__.py
+++ b/cl_sii/rcv/__init__.py
@@ -1,11 +1,12 @@
 """
-SII RCV ("Registro de Compras y Ventas").
+SII RCV ("Registro de Compras y Ventas")
+========================================
 
-.. note::
-    The RCV ("Registro de Compras y Ventas") is composed of 2 "registros":
-    RC ("Registro de Compras") and RV ("Registro de Ventas").
+The RCV ("Registro de Compras y Ventas") is composed of 2 "registros":
+RC ("Registro de Compras") and RV ("Registro de Ventas").
 
 .. seealso::
-    http://www.sii.cl/preguntas_frecuentes/catastro/001_012_6971.htm
+    See SII / FAQ /
+    `¿Qué es el Registro de Compras y Ventas (RCV)? <http://www.sii.cl/preguntas_frecuentes/catastro/001_012_6971.htm>`_  # noqa: E501
 
 """

--- a/cl_sii/rcv/constants.py
+++ b/cl_sii/rcv/constants.py
@@ -1,0 +1,292 @@
+import enum
+
+from ..dte.constants import TipoDteEnum
+
+
+@enum.unique
+class RcvKind(enum.Enum):
+    """
+    The kind of RCV.
+
+    Definitions:
+
+    * Registro de Compras (RC):
+      > [..] todas las operaciones de compras realizadas por un contribuyente
+      > de acuerdo a los DTEs recepcionados por el SII, complementado con los
+      > documentos tributarios de compras, en soporte distinto al electrónico,
+      > en el cual deberá indicarse la naturaleza de las operaciones en
+      > cuanto a la procedencia e identificación del crédito fiscal.
+
+    * Registro de Ventas (RV):
+      > [..] todas las operaciones de ventas realizadas por un contribuyente
+      > de acuerdo a los DTEs recibidos en el SII.
+
+    Definitions source: RCV_FAQ_
+
+    .. _RCV_FAQ: http://www.sii.cl/ayudas/ayudas_por_servicios/rcv_faqs.pdf
+
+    """
+
+    COMPRAS = 'COMPRAS'
+    """RCV / compras."""
+
+    VENTAS = 'VENTAS'
+    """RCV / ventas."""
+
+
+@enum.unique
+class RcEstadoContable(enum.Enum):
+    """
+    The "Estado Contable" of a "Registro de compras" (RC).
+
+    Applies to ``RcvKind.COMPRAS``.
+
+    Definitions:
+
+    * "Registro":
+      > [..] los Documentos Tributarios Electrónicos (DTE) y no Electrónicos
+      > que conforman la Información de Compras válida, la cual se utiliza para
+      > la determinación impositiva y es considerada como el registro oficial
+      > del Contribuyente y respaldo de su contabilidad.
+
+    * "No incluir":
+      > [..] los Documentos Tributarios Electrónicos (DTE) y no Electrónicos
+      > que no deben incluirse en el Registro de Compras, en virtud de
+      > corresponder a compras y pagos de servicios que no tienen relación con
+      > las actividades económicas del contribuyente y por lo tanto no deben
+      > afectar la determinación impositiva.
+
+    * "Reclamado(s)":
+      > [..] los Documentos Tributarios Electrónicos (DTE) que han sido
+      > reclamados por el mismo receptor en el Registro de Aceptación o Reclamo
+      > de un DTE.
+      > Por encontrarse en estado "Reclamado", no es posible ingresar estos
+      > documentos en el Registro de Compras vigente o considerarse para la
+      > determinación impositiva.
+
+    * "Pendiente(s)":
+      > [..] los Documentos Tributarios Electrónicos (DTE) que han sido
+      > recibidos en el SII, pero que se encuentran pendientes de otorgarse el
+      > Acuse de Recibo o entregarse un Reclamo por parte del receptor [..].
+
+    Definitions source: RCV_web_app_
+
+    .. _RCV_web_app: https://www4.sii.cl/consdcvinternetui/#/index
+
+    """
+
+    REGISTRO = 'REGISTRO'
+    NO_INCLUIR = 'NO_INCLUIR'
+    RECLAMADO = 'RECLAMADO'
+    PENDIENTE = 'PENDIENTE'
+
+
+@enum.unique
+class RcvTipoDocto(enum.IntEnum):
+
+    """
+    Enum of "Tipo de Documento" for the RCV domain.
+
+    Unlike :class:`cl_sii.dte.constants.TipoDteEnum` this collection is not
+    restricted to "documentos electrónicos". However, this is not a superset
+    of the latter (e.g. "Guía electrónica de despacho" (52) is in
+    ``TipoDteEnum`` but not in ``RcvTipoDocto``).
+
+    Sources:
+
+    * XML type (enum) ``DoctoType`` ("Tipos de Documentos") in
+      official schema ``LibroCV_v10.xsd``.
+      https://github.com/fyndata/lib-cl-sii-python/blob/f57a326/cl_sii/data/ref/factura_electronica/schemas-xml/LibroCV_v10.xsd#L1563-L1622
+
+    * Values returned by SII endpoint
+      https://www4.sii.cl/consdcvinternetui/services/data/facadeService/getDatosInicio
+
+    * Constant ``cl_sii_api.rcv.AVAILABLE_DOCUMENT_TYPES`` in package
+      ``cl-sii-api`` v0.2.2.
+      https://github.com/fynpal/lib-cl-sii-api-python/blob/81b4a43/cl_sii_api/rcv.py
+
+    """
+
+    ###########################################################################
+    # "facturas"
+    ###########################################################################
+
+    FACTURA_INICIO = 29
+    """Factura de inicio."""
+
+    FACTURA = 30
+    """Factura."""
+
+    FACTURA_ELECTRONICA = 33
+    """Factura electrónica de venta."""
+
+    FACTURA_NO_AFECTA_O_EXENTA = 32
+    """Factura de venta, no afecta o exenta de IVA."""
+    # aka 'Factura no Afecta o Exenta'
+    # aka 'Factura de Venta de Bienes y Servicios No afectos o Exento de IVA'
+
+    FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA = 34
+    """Factura electrónica de venta, no afecta o exenta de IVA."""
+    # aka 'Factura no Afecta o Exenta Electrónica'
+    # aka 'Factura Electrónica de Venta de Bienes y Servicios No afectos o Exento de IVA'
+
+    FACTURA_COMPRA = 45
+    """Factura de compra."""
+
+    FACTURA_COMPRA_ELECTRONICA = 46
+    """Factura electrónica de compra."""
+    # aka 'Factura de Compra Electrónica'
+    # Name should have been 'Factura Electrónica de Compra'.
+
+    FACTURA_EXPORTACION = 101
+    """Factura de Exportación."""
+
+    FACTURA_EXPORTACION_ELECTRONICA = 110
+    """Factura Electrónica de Exportación."""
+    # aka 'Factura de Exportación Electrónica'
+    # Name should have been 'Factura Electrónica de Exportación'.
+
+    ###########################################################################
+    # "notas"
+    ###########################################################################
+
+    NOTA_DEBITO = 55
+    """Nota de débito."""
+
+    NOTA_DEBITO_ELECTRONICA = 56
+    """Nota electrónica de débito."""
+    # aka 'Nota de Débito Electrónica'
+
+    NOTA_CREDITO = 60
+    """Nota de crédito."""
+
+    NOTA_CREDITO_ELECTRONICA = 61
+    """Nota electrónica de crédito."""
+    # aka 'Nota de Crédito Electrónica'
+
+    NOTA_DEBITO_EXPORTACION = 104
+    """Nota de débito de exportación."""
+
+    NOTA_DEBITO_EXPORTACION_ELECTRONICA = 111
+    """Nota electrónica de débito de exportación."""
+
+    NOTA_CREDITO_EXPORTACION = 106
+    """Nota de crédito de exportación."""
+
+    NOTA_CREDITO_EXPORTACION_ELECTRONICA = 112
+    """Nota electrónica de crédito de exportación."""
+
+    ###########################################################################
+    # "liquidación-factura"
+    ###########################################################################
+
+    # For more info about a "liquidación-factura" see:
+    #   http://www.sii.cl/preguntas_frecuentes/catastro/001_012_0247.htm
+    #   http://www.sii.cl/preguntas_frecuentes/catastro/001_012_3689.htm
+
+    LIQUIDACION_FACTURA = 40
+    """Liquidación-Factura."""
+
+    LIQUIDACION_FACTURA_ELECTRONICA = 43
+    """Liquidación-Factura Electrónica."""
+
+    ###########################################################################
+    # "Total Op. del mes Boleta X"
+    ###########################################################################
+
+    TOTAL_OP_DEL_MES_BOLETA_AFECTA = 35
+    """Total Oper. del mes Boleta Afecta."""
+
+    TOTAL_OP_DEL_MES_BOLETA_EXENTA = 38
+    """Total Oper. del mes Boleta Exenta."""
+
+    TOTAL_OP_DEL_MES_BOLETA_EXENTA_ELECTR = 41
+    """Total Op. del mes Boleta Exenta Electr."""
+
+    TOTAL_OP_DEL_MES_BOLETA_ELECTR = 39
+    """Total Oper. del mes Boleta Electr."""
+
+    ###########################################################################
+    # uncommon
+    ###########################################################################
+
+    TIPO_47 = 47
+    """Total del mes Vale Electrónico Especial."""
+
+    TIPO_48 = 48
+    """Total mes Comprobantes Pago Electrónico."""
+
+    TIPO_102 = 102
+    """Factura vta. Exenta a Zona Franca Prim."""
+
+    TIPO_103 = 103
+    """Liquidación."""
+
+    TIPO_105 = 105
+    """Total Op. mes Boleta Liq. Res. 1423/76."""
+
+    TIPO_108 = 108
+    """SRF Solicitud Registro de Factura."""
+
+    TIPO_109 = 109
+    """Factura Turista."""
+
+    TIPO_901 = 901
+    """Fact. Vta. Emp. Terr. Pref. Res. 1057/85."""
+
+    TIPO_902 = 902
+    """Conocimiento Embarque Marítimo o Aéreo."""
+
+    TIPO_903 = 903
+    """Documento Único de Salida (DUS)."""
+
+    TIPO_904 = 904
+    """Factura de Traspaso."""
+
+    TIPO_905 = 905
+    """Factura de Reexpedición."""
+
+    TIPO_906 = 906
+    """Total Op. del mes Boleta Vta. Módulo ZF."""
+
+    TIPO_907 = 907
+    """Facturas Venta Módulo ZF."""
+
+    TIPO_909 = 909
+    """Facturas Venta Módulo ZF."""
+
+    TIPO_910 = 910
+    """Solicitud Traslado Zona Franca (ZF)."""
+
+    TIPO_911 = 911
+    """Decl. de Ingreso a Zona Franca Primaria."""
+
+    TIPO_914 = 914
+    """Declaración de Ingreso (DIN)."""
+
+    TIPO_919 = 919
+    """Resumen Vtas. Pasajes Nac. sin Factura."""
+
+    TIPO_920 = 920
+    """Otros registros no Docum. Aumenta Débito."""
+
+    TIPO_922 = 922
+    """Otros registros no Doc. Disminuye Débito."""
+
+    TIPO_924 = 924
+    """Resumen Vtas. Pasajes Inter. sin Fact."""
+
+    def as_tipo_dte(self) -> TipoDteEnum:
+        """
+        Return equivalent "Tipo DTE".
+
+        :raises ValueError: if there is no equivalent one
+
+        """
+        try:
+            value = TipoDteEnum(self.value)
+        except ValueError as exc:
+            raise ValueError(
+                f"There is no equivalent 'TipoDteEnum' for 'RcvTipoDocto.{self.name}'.") from exc
+
+        return value

--- a/cl_sii/rcv/data_models.py
+++ b/cl_sii/rcv/data_models.py
@@ -1,0 +1,327 @@
+"""
+RCV data models
+===============
+
+
+"""
+from __future__ import annotations
+
+import dataclasses
+import logging
+from dataclasses import field as dc_field
+from datetime import date, datetime
+from typing import Optional
+
+import cl_sii.dte.data_models
+from cl_sii.base.constants import SII_OFFICIAL_TZ
+from cl_sii.libs import tz_utils
+from cl_sii.rut import Rut
+
+from .constants import RcEstadoContable, RcvKind, RcvTipoDocto
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class PeriodoTributario:
+
+    year: int = dc_field()
+    month: int = dc_field()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.year, int):
+            raise TypeError("Inappropriate type of 'year'.")
+        if self.year < 1900:  # arbitrary number but it more useful than checking not < 1.
+            raise ValueError("Value is out of the valid range for 'year'.")
+
+        if not isinstance(self.month, int):
+            raise TypeError("Inappropriate type of 'month'.")
+        if self.month < 1 or self.month > 12:
+            raise ValueError("Value is out of the valid range for 'month'.")
+
+    ###########################################################################
+    # dunder/magic methods
+    ###########################################################################
+
+    def __str__(self) -> str:
+        # 'YYYY-MM' e.g. '2018-03'
+        return f"{self.year}-{self.month:02d}"
+
+    def __lt__(self, other: PeriodoTributario) -> bool:
+        return self.as_date() < other.as_date()
+
+    def __le__(self, other: PeriodoTributario) -> bool:
+        return self.as_date() <= other.as_date()
+
+    ###########################################################################
+    # custom methods
+    ###########################################################################
+
+    @property
+    def is_in_the_future(self) -> bool:
+        return self.as_datetime() > tz_utils.get_now_tz_aware()
+
+    @classmethod
+    def from_date(cls, value: date) -> PeriodoTributario:
+        return PeriodoTributario(year=value.year, month=value.month)
+
+    @classmethod
+    def from_datetime(cls, value: datetime) -> PeriodoTributario:
+        value_naive = tz_utils.convert_tz_aware_dt_to_naive(value, SII_OFFICIAL_TZ)
+        return cls.from_date(value_naive.date())
+
+    def as_date(self) -> date:
+        return date(self.year, self.month, day=1)
+
+    def as_datetime(self) -> datetime:
+        # note: timezone-aware
+        return datetime(self.year, self.month, day=1, hour=0, minute=0, second=0).replace(
+            tzinfo=SII_OFFICIAL_TZ)
+
+
+@dataclasses.dataclass(frozen=True)
+class RcvDetalleEntry:
+
+    """
+    Entry of the "detalle" of an RCV.
+    """
+
+    ###########################################################################
+    # constants
+    ###########################################################################
+
+    # note: as of Python 3.7.3 we can not do something like `RCV_KIND: Optional[RcvKind] = None`
+    #   because 'dataclasses' gets confused and assumes that that class attribute is a dataclass
+    #   field (it is not), and this error is triggered:
+    #   > TypeError: non-default argument 'my_dc_field' follows default argument
+
+    RCV_KIND = None  # type: Optional[RcvKind]
+    RC_ESTADO_CONTABLE = None  # type: Optional[RcEstadoContable]
+
+    ###########################################################################
+    # fields
+    ###########################################################################
+
+    emisor_rut: Rut = dc_field()
+    """
+    RUT of the "emisor" of the "documento".
+    """
+
+    tipo_docto: RcvTipoDocto = dc_field()
+    """
+    The kind of "documento".
+    """
+
+    folio: int = dc_field()
+    """
+    The sequential number of a "documento".
+    """
+
+    # TODO: docstring
+    fecha_emision_date: date = dc_field()
+
+    # TODO: docstring
+    # TODO: can it be None? What happens for those "tipo docto" that do not have a receptor?
+    receptor_rut: Rut = dc_field()
+
+    monto_total: int = dc_field()
+    """
+    Total amount of the "documento".
+    """
+
+    emisor_razon_social: str = dc_field()
+    """
+    "Razón social" (legal name) of the "emisor" of the "documento".
+    """
+
+    # TODO: docstring
+    # TODO: can it be None? What happens for those "tipo docto" that do not have a receptor?
+    receptor_razon_social: str = dc_field()
+
+    # TODO: docstring
+    # note: must be timezone-aware.
+    fecha_recepcion_dt: datetime = dc_field()
+
+    def __post_init__(self) -> None:
+        """
+        Run validation automatically after setting the fields values.
+
+        :raises TypeError, ValueError:
+
+        """
+        if self.RCV_KIND == RcvKind.COMPRAS:
+            if self.RC_ESTADO_CONTABLE is None:
+                raise ValueError(
+                    "'RC_ESTADO_CONTABLE' must not be None when 'RCV_KIND' is 'COMPRAS'.")
+        elif self.RCV_KIND == RcvKind.VENTAS:
+            if self.RC_ESTADO_CONTABLE is not None:
+                raise ValueError(
+                    "'RC_ESTADO_CONTABLE' must be None when 'RCV_KIND' is 'VENTAS'.")
+
+        if not isinstance(self.emisor_rut, Rut):
+            raise TypeError("Inappropriate type of 'emisor_rut'.")
+
+        if not isinstance(self.tipo_docto, RcvTipoDocto):
+            raise TypeError("Inappropriate type of 'tipo_docto'.")
+
+        if not isinstance(self.folio, int):
+            raise TypeError("Inappropriate type of 'folio'.")
+        if not self.folio > 0:
+            raise ValueError("Inappropriate value of 'folio'.")
+
+        if not isinstance(self.fecha_emision_date, date):
+            raise TypeError("Inappropriate type of 'fecha_emision_date'.")
+
+        if not isinstance(self.receptor_rut, Rut):
+            raise TypeError("Inappropriate type of 'receptor_rut'.")
+
+        # TODO: figure out validation rules of 'monto_total'
+        if not isinstance(self.monto_total, int):
+            raise TypeError("Inappropriate type of 'monto_total'.")
+
+        if not isinstance(self.emisor_razon_social, str):
+            raise TypeError("Inappropriate type of 'emisor_razon_social'.")
+        cl_sii.dte.data_models.validate_contribuyente_razon_social(self.emisor_razon_social)
+
+        if not isinstance(self.receptor_razon_social, str):
+            raise TypeError("Inappropriate type of 'receptor_razon_social'.")
+        cl_sii.dte.data_models.validate_contribuyente_razon_social(self.receptor_razon_social)
+
+        if not isinstance(self.fecha_recepcion_dt, datetime):
+            raise TypeError("Inappropriate type of 'fecha_recepcion_dt'.")
+        tz_utils.validate_dt_tz(self.fecha_recepcion_dt, SII_OFFICIAL_TZ)
+
+    @property
+    def is_dte(self) -> bool:
+        try:
+            self.tipo_docto.as_tipo_dte()
+        except ValueError:
+            return False
+        return True
+
+    def as_dte_data_l2(self) -> cl_sii.dte.data_models.DteDataL2:
+        try:
+            tipo_dte = self.tipo_docto.as_tipo_dte()
+
+            dte_data = cl_sii.dte.data_models.DteDataL2(
+                emisor_rut=self.emisor_rut,
+                tipo_dte=tipo_dte,
+                folio=self.folio,
+                fecha_emision_date=self.fecha_emision_date,
+                receptor_rut=self.receptor_rut,
+                monto_total=self.monto_total,
+                emisor_razon_social=self.emisor_razon_social,
+                receptor_razon_social=self.receptor_razon_social,
+                # fecha_vencimiento_date='',
+                # firma_documento_dt='',
+                # signature_value='',
+                # signature_x509_cert_der='',
+                # emisor_giro='',
+                # emisor_email='',
+                # receptor_email='',
+            )
+        except (TypeError, ValueError):
+            raise
+
+        return dte_data
+
+
+@dataclasses.dataclass(frozen=True)
+class RvDetalleEntry(RcvDetalleEntry):
+
+    """
+    Entry of the "detalle" of an RV ("Registro de Ventas").
+    """
+
+    RCV_KIND = RcvKind.VENTAS
+    RC_ESTADO_CONTABLE = None
+
+    # TODO: docstring
+    # note: must be timezone-aware.
+    fecha_acuse_dt: Optional[datetime] = dc_field()
+
+    # TODO: docstring
+    # note: must be timezone-aware.
+    fecha_reclamo_dt: Optional[datetime] = dc_field()
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+
+        if self.fecha_acuse_dt is not None:
+            if not isinstance(self.fecha_acuse_dt, datetime):
+                raise TypeError("Inappropriate type of 'fecha_acuse_dt'.")
+            tz_utils.validate_dt_tz(self.fecha_acuse_dt, SII_OFFICIAL_TZ)
+
+        if self.fecha_reclamo_dt is not None:
+            if not isinstance(self.fecha_reclamo_dt, datetime):
+                raise TypeError("Inappropriate type of 'fecha_reclamo_dt'.")
+            tz_utils.validate_dt_tz(self.fecha_reclamo_dt, SII_OFFICIAL_TZ)
+
+
+@dataclasses.dataclass(frozen=True)
+class RcRegistroDetalleEntry(RcvDetalleEntry):
+
+    """
+    Entry of the "detalle" of an RC ("Registro de Compras") / "registro".
+    """
+
+    RCV_KIND = RcvKind.COMPRAS
+    RC_ESTADO_CONTABLE = RcEstadoContable.REGISTRO
+
+    # TODO: docstring
+    # note: must be timezone-aware.
+    fecha_acuse_dt: Optional[datetime] = dc_field()
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+
+        if self.fecha_acuse_dt is not None:
+            if not isinstance(self.fecha_acuse_dt, datetime):
+                raise TypeError("Inappropriate type of 'fecha_acuse_dt'.")
+            tz_utils.validate_dt_tz(self.fecha_acuse_dt, SII_OFFICIAL_TZ)
+
+
+@dataclasses.dataclass(frozen=True)
+class RcNoIncluirDetalleEntry(RcRegistroDetalleEntry):
+
+    """
+    Entry of the "detalle" of an RC ("Registro de Compras") / "no incluir".
+    """
+
+    RCV_KIND = RcvKind.COMPRAS
+    RC_ESTADO_CONTABLE = RcEstadoContable.NO_INCLUIR
+
+
+@dataclasses.dataclass(frozen=True)
+class RcReclamadoDetalleEntry(RcvDetalleEntry):
+
+    """
+    Entry of the "detalle" of an RC ("Registro de Compras") / "reclamado".
+    """
+
+    RCV_KIND = RcvKind.COMPRAS
+    RC_ESTADO_CONTABLE = RcEstadoContable.RECLAMADO
+
+    # TODO: docstring
+    # note: must be timezone-aware.
+    fecha_reclamo_dt: Optional[datetime] = dc_field()
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+
+        if self.fecha_reclamo_dt is not None:
+            if not isinstance(self.fecha_reclamo_dt, datetime):
+                raise TypeError("Inappropriate type of 'fecha_reclamo_dt'.")
+            tz_utils.validate_dt_tz(self.fecha_reclamo_dt, SII_OFFICIAL_TZ)
+
+
+@dataclasses.dataclass(frozen=True)
+class RcPendienteDetalleEntry(RcvDetalleEntry):
+
+    """
+    Entry of the "detalle" of an RC ("Registro de Compras") / "pendiente".
+    """
+
+    RCV_KIND = RcvKind.COMPRAS
+    RC_ESTADO_CONTABLE = RcEstadoContable.PENDIENTE

--- a/tests/test_extras_mm_fields.py
+++ b/tests/test_extras_mm_fields.py
@@ -3,7 +3,11 @@ import unittest
 
 import marshmallow
 
-from cl_sii.extras.mm_fields import Rut, RutField, TipoDteEnum, TipoDteField
+from cl_sii.extras.mm_fields import (
+    RcvTipoDocto, RcvTipoDoctoField,
+    Rut, RutField,
+    TipoDteEnum, TipoDteField,
+)
 
 
 class RutFieldTest(unittest.TestCase):
@@ -290,3 +294,148 @@ class TipoDteFieldTest(unittest.TestCase):
         self.assertDictEqual(errors, {'tipo_dte': ['Invalid input type.']})
         data, errors = schema.dump(obj_invalid_5)
         self.assertDictEqual(errors, {'tipo_dte': ['Invalid input type.']})
+
+
+class RcvTipoDoctoFieldTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+
+        class MyObj:
+            def __init__(self, tipo_docto: RcvTipoDocto, other_field: int = None) -> None:
+                self.tipo_docto = tipo_docto
+                self.other_field = other_field
+
+        class MyBadObj:
+            def __init__(self, some_field: int) -> None:
+                self.some_field = some_field
+
+        class MyMmSchema(marshmallow.Schema):
+
+            class Meta:
+                strict = False
+
+            tipo_docto = RcvTipoDoctoField(
+                required=True,
+                load_from='source field name',
+            )
+            other_field = marshmallow.fields.Integer(
+                required=False,
+            )
+
+        class MyMmSchemaStrict(marshmallow.Schema):
+
+            class Meta:
+                strict = True
+
+            tipo_docto = RcvTipoDoctoField(
+                required=True,
+                load_from='source field name',
+            )
+            other_field = marshmallow.fields.Integer(
+                required=False,
+            )
+
+        self.MyObj = MyObj
+        self.MyBadObj = MyBadObj
+        self.MyMmSchema = MyMmSchema
+        self.MyMmSchemaStrict = MyMmSchemaStrict
+
+    def test_load_ok_valid(self) -> None:
+        schema = self.MyMmSchema()
+
+        data_valid_1 = {'source field name': 33}
+        data_valid_2 = {'source field name': RcvTipoDocto(33)}
+        data_valid_3 = {'source field name': '  33 \t '}
+
+        result = schema.load(data_valid_1)
+        self.assertDictEqual(dict(result.data), {'tipo_docto': RcvTipoDocto(33)})
+        self.assertDictEqual(dict(result.errors), {})
+
+        result = schema.load(data_valid_2)
+        self.assertDictEqual(dict(result.data), {'tipo_docto': RcvTipoDocto(33)})
+        self.assertDictEqual(dict(result.errors), {})
+
+        result = schema.load(data_valid_3)
+        self.assertDictEqual(dict(result.data), {'tipo_docto': RcvTipoDocto(33)})
+        self.assertDictEqual(dict(result.errors), {})
+
+    def test_dump_ok_valid(self) -> None:
+        schema = self.MyMmSchema()
+
+        obj_valid_1 = self.MyObj(tipo_docto=RcvTipoDocto(33))
+        obj_valid_2 = self.MyObj(tipo_docto=None)
+
+        data, errors = schema.dump(obj_valid_1)
+        self.assertDictEqual(data, {'tipo_docto': 33, 'other_field': None})
+        self.assertDictEqual(errors, {})
+
+        data, errors = schema.dump(obj_valid_2)
+        self.assertDictEqual(data, {'tipo_docto': None, 'other_field': None})
+        self.assertDictEqual(errors, {})
+
+    def test_dump_ok_strange(self) -> None:
+        # If the class of the object to be dumped has attributes that do not match at all the
+        #   fields of the schema, there are no errors! Even if the schema has `strict = True` set.
+
+        schema = self.MyMmSchema()
+        schema_strict = self.MyMmSchemaStrict()
+
+        obj_valid_1 = self.MyBadObj(some_field=123)
+        obj_valid_2 = self.MyBadObj(some_field=None)
+
+        data, errors = schema.dump(obj_valid_1)
+        self.assertEqual((data, errors), ({}, {}))
+
+        data, errors = schema_strict.dump(obj_valid_1)
+        self.assertEqual((data, errors), ({}, {}))
+
+        data, errors = schema.dump(obj_valid_2)
+        self.assertEqual((data, errors), ({}, {}))
+
+        data, errors = schema_strict.dump(obj_valid_2)
+        self.assertEqual((data, errors), ({}, {}))
+
+    def test_load_fail(self) -> None:
+
+        schema = self.MyMmSchema()
+
+        data_invalid_1 = {'source field name': '123'}
+        data_invalid_2 = {'source field name': True}
+        data_invalid_3 = {'source field name': None}
+        data_invalid_4 = {}
+
+        result = schema.load(data_invalid_1)
+        self.assertDictEqual(dict(result.data), {})
+        self.assertDictEqual(dict(result.errors), {'source field name': ["Not a valid RCV's Tipo de Documento."]})  # noqa: E501
+
+        result = schema.load(data_invalid_2)
+        self.assertDictEqual(dict(result.data), {})
+        self.assertDictEqual(dict(result.errors), {'source field name': ['Invalid input type.']})
+
+        result = schema.load(data_invalid_3)
+        self.assertDictEqual(dict(result.data), {})
+        self.assertDictEqual(dict(result.errors), {'source field name': ['Field may not be null.']})
+
+        result = schema.load(data_invalid_4)
+        self.assertDictEqual(dict(result.data), {})
+        self.assertDictEqual(dict(result.errors), {'source field name': ['Missing data for required field.']})  # noqa: E501
+
+    def test_dump_fail(self) -> None:
+        schema = self.MyMmSchema()
+
+        obj_invalid_1 = self.MyObj(tipo_docto=100)
+        obj_invalid_2 = self.MyObj(tipo_docto=True)
+        obj_invalid_3 = self.MyObj(tipo_docto='FACTURA_ELECTRONICA')
+        obj_invalid_4 = self.MyObj(tipo_docto='')
+        obj_invalid_5 = self.MyObj(tipo_docto=date(2018, 12, 23))
+
+        data, errors = schema.dump(obj_invalid_1)
+        self.assertDictEqual(errors, {'tipo_docto': ["Not a valid RCV's Tipo de Documento."]})
+        data, errors = schema.dump(obj_invalid_2)
+        self.assertDictEqual(errors, {'tipo_docto': ['Invalid input type.']})
+        data, errors = schema.dump(obj_invalid_3)
+        self.assertDictEqual(errors, {'tipo_docto': ['Invalid input type.']})
+        data, errors = schema.dump(obj_invalid_4)
+        self.assertDictEqual(errors, {'tipo_docto': ['Invalid input type.']})
+        data, errors = schema.dump(obj_invalid_5)
+        self.assertDictEqual(errors, {'tipo_docto': ['Invalid input type.']})

--- a/tests/test_rcv_constants.py
+++ b/tests/test_rcv_constants.py
@@ -1,0 +1,125 @@
+import unittest
+
+from cl_sii.dte.constants import TipoDteEnum  # noqa: F401
+from cl_sii.rcv import constants  # noqa: F401
+from cl_sii.rcv.constants import RcEstadoContable, RcvKind, RcvTipoDocto  # noqa: F401
+
+
+class RcvKindTest(unittest.TestCase):
+
+    def test_members(self):
+        self.assertSetEqual(
+            {x for x in RcvKind},
+            {
+                RcvKind.COMPRAS,
+                RcvKind.VENTAS,
+            }
+        )
+
+    def test_values_type(self):
+        self.assertSetEqual(
+            {type(x.value) for x in RcvKind},
+            {str}
+        )
+
+
+class RcEstadoContableTest(unittest.TestCase):
+
+    def test_members(self):
+        self.assertSetEqual(
+            {x for x in RcEstadoContable},
+            {
+                RcEstadoContable.REGISTRO,
+                RcEstadoContable.NO_INCLUIR,
+                RcEstadoContable.RECLAMADO,
+                RcEstadoContable.PENDIENTE,
+            }
+        )
+
+    def test_values_type(self):
+        self.assertSetEqual(
+            {type(x.value) for x in RcEstadoContable},
+            {str}
+        )
+
+
+class RcvTipoDoctoTest(unittest.TestCase):
+
+    def test_members(self):
+        self.assertSetEqual(
+            {x for x in RcvTipoDocto},
+            {
+                RcvTipoDocto.FACTURA_INICIO,
+                RcvTipoDocto.FACTURA,
+                RcvTipoDocto.FACTURA_ELECTRONICA,
+                RcvTipoDocto.FACTURA_NO_AFECTA_O_EXENTA,
+                RcvTipoDocto.FACTURA_NO_AFECTA_O_EXENTA_ELECTRONICA,
+                RcvTipoDocto.FACTURA_COMPRA,
+                RcvTipoDocto.FACTURA_COMPRA_ELECTRONICA,
+                RcvTipoDocto.FACTURA_EXPORTACION,
+                RcvTipoDocto.FACTURA_EXPORTACION_ELECTRONICA,
+
+                RcvTipoDocto.NOTA_DEBITO,
+                RcvTipoDocto.NOTA_DEBITO_ELECTRONICA,
+                RcvTipoDocto.NOTA_CREDITO,
+                RcvTipoDocto.NOTA_CREDITO_ELECTRONICA,
+                RcvTipoDocto.NOTA_DEBITO_EXPORTACION,
+                RcvTipoDocto.NOTA_DEBITO_EXPORTACION_ELECTRONICA,
+                RcvTipoDocto.NOTA_CREDITO_EXPORTACION,
+                RcvTipoDocto.NOTA_CREDITO_EXPORTACION_ELECTRONICA,
+
+                RcvTipoDocto.LIQUIDACION_FACTURA,
+                RcvTipoDocto.LIQUIDACION_FACTURA_ELECTRONICA,
+
+                RcvTipoDocto.TOTAL_OP_DEL_MES_BOLETA_AFECTA,
+                RcvTipoDocto.TOTAL_OP_DEL_MES_BOLETA_EXENTA,
+                RcvTipoDocto.TOTAL_OP_DEL_MES_BOLETA_EXENTA_ELECTR,
+                RcvTipoDocto.TOTAL_OP_DEL_MES_BOLETA_ELECTR,
+
+                RcvTipoDocto.TIPO_47,
+                RcvTipoDocto.TIPO_48,
+                RcvTipoDocto.TIPO_102,
+                RcvTipoDocto.TIPO_103,
+                RcvTipoDocto.TIPO_105,
+                RcvTipoDocto.TIPO_108,
+                RcvTipoDocto.TIPO_109,
+                RcvTipoDocto.TIPO_901,
+                RcvTipoDocto.TIPO_902,
+                RcvTipoDocto.TIPO_903,
+                RcvTipoDocto.TIPO_904,
+                RcvTipoDocto.TIPO_905,
+                RcvTipoDocto.TIPO_906,
+                RcvTipoDocto.TIPO_907,
+                RcvTipoDocto.TIPO_909,
+                RcvTipoDocto.TIPO_910,
+                RcvTipoDocto.TIPO_911,
+                RcvTipoDocto.TIPO_914,
+                RcvTipoDocto.TIPO_919,
+                RcvTipoDocto.TIPO_920,
+                RcvTipoDocto.TIPO_922,
+                RcvTipoDocto.TIPO_924,
+            }
+        )
+
+    def test_values_type(self):
+        self.assertSetEqual(
+            {type(x.value) for x in RcvTipoDocto},
+            {int}
+        )
+
+    def test_of_some_member(self):
+        value = RcvTipoDocto.FACTURA_ELECTRONICA
+
+        self.assertEqual(value.name, 'FACTURA_ELECTRONICA')
+        self.assertEqual(value.value, 33)
+
+    def test_as_tipo_dte(self):
+        self.assertEqual(
+            RcvTipoDocto.FACTURA_ELECTRONICA.as_tipo_dte(),
+            TipoDteEnum.FACTURA_ELECTRONICA)
+
+        with self.assertRaises(ValueError) as cm:
+            RcvTipoDocto.FACTURA.as_tipo_dte()
+        self.assertEqual(
+            cm.exception.args,
+            ("There is no equivalent 'TipoDteEnum' for 'RcvTipoDocto.FACTURA'.", ))


### PR DESCRIPTION
- Add module `rcv.data_models`.
- Add module `rcv.constants`.
- Add marshmallow field `RcvTipoDoctoField` (for RCV's "tipo documento").