### PR TITLE
rcv.parse_csv: detect invalid value of "razon social"

### DIFF
--- a/cl_sii/rcv/parse_csv.py
+++ b/cl_sii/rcv/parse_csv.py
@@ -13,6 +13,7 @@ import marshmallow
 import marshmallow.fields
 import marshmallow.validate
 
+import cl_sii.dte.data_models
 from cl_sii.base.constants import SII_OFFICIAL_TZ
 from cl_sii.extras import mm_fields
 from cl_sii.libs import csv_utils
@@ -42,6 +43,11 @@ def parse_rcv_venta_csv_file(
     Parse entries from an RV ("Registro de Ventas") (CSV file).
 
     """
+    # warning: this looks like it would be executed before the iteration begins but it is not.
+    if not isinstance(razon_social, str):
+        raise TypeError("Inappropriate type of 'razon_social'.")
+    cl_sii.dte.data_models.validate_contribuyente_razon_social(razon_social)
+
     schema_context = dict(
         emisor_rut=rut,
         emisor_razon_social=razon_social,
@@ -154,6 +160,11 @@ def parse_rcv_compra_registro_csv_file(
     Parse entries from an RC ("Registro de Compras") / "registro" (CSV file).
 
     """
+    # warning: this looks like it would be executed before the iteration begins but it is not.
+    if not isinstance(razon_social, str):
+        raise TypeError("Inappropriate type of 'razon_social'.")
+    cl_sii.dte.data_models.validate_contribuyente_razon_social(razon_social)
+
     schema_context = dict(
         receptor_rut=rut,
         receptor_razon_social=razon_social,
@@ -235,6 +246,11 @@ def parse_rcv_compra_no_incluir_csv_file(
     Parse entries from an RC ("Registro de Compras") / "no incluir" (CSV file).
 
     """
+    # warning: this looks like it would be executed before the iteration begins but it is not.
+    if not isinstance(razon_social, str):
+        raise TypeError("Inappropriate type of 'razon_social'.")
+    cl_sii.dte.data_models.validate_contribuyente_razon_social(razon_social)
+
     schema_context = dict(
         receptor_rut=rut,
         receptor_razon_social=razon_social,
@@ -310,6 +326,11 @@ def parse_rcv_compra_reclamado_csv_file(
     Parse entries from an RC ("Registro de Compras") / "reclamado" (CSV file).
 
     """
+    # warning: this looks like it would be executed before the iteration begins but it is not.
+    if not isinstance(razon_social, str):
+        raise TypeError("Inappropriate type of 'razon_social'.")
+    cl_sii.dte.data_models.validate_contribuyente_razon_social(razon_social)
+
     schema_context = dict(
         receptor_rut=rut,
         receptor_razon_social=razon_social,
@@ -385,6 +406,11 @@ def parse_rcv_compra_pendiente_csv_file(
     Parse entries from an RC ("Registro de Compras") / "pendiente" (CSV file).
 
     """
+    # warning: this looks like it would be executed before the iteration begins but it is not.
+    if not isinstance(razon_social, str):
+        raise TypeError("Inappropriate type of 'razon_social'.")
+    cl_sii.dte.data_models.validate_contribuyente_razon_social(razon_social)
+
     schema_context = dict(
         receptor_rut=rut,
         receptor_razon_social=razon_social,

--- a/tests/test_rcv_parse_csv.py
+++ b/tests/test_rcv_parse_csv.py
@@ -9,6 +9,7 @@ from cl_sii.rcv.parse_csv import (  # noqa: F401
     parse_rcv_venta_csv_file,
     _parse_rcv_csv_file,
 )
+from cl_sii.rut import Rut
 
 
 class RcvVentaCsvRowSchemaTest(unittest.TestCase):
@@ -47,21 +48,106 @@ class FunctionsTest(unittest.TestCase):
         # TODO: implement for 'parse_rcv_venta_csv_file'.
         pass
 
+    def test_fail_parse_rcv_venta_csv_file_bad_razon_social(self) -> None:
+        other_kwargs = dict(rut=Rut('1-9'), input_file_path='x')
+
+        with self.assertRaises(TypeError) as cm:
+            next(parse_rcv_venta_csv_file(razon_social=1, **other_kwargs))
+        self.assertEqual(cm.exception.args, ("Inappropriate type of 'razon_social'.", ))
+
+        with self.assertRaises(ValueError) as cm:
+            next(parse_rcv_venta_csv_file(razon_social='', **other_kwargs))
+        self.assertEqual(cm.exception.args, ("Value must not be empty.", ))
+
+        with self.assertRaises(ValueError) as cm:
+            next(parse_rcv_venta_csv_file(razon_social=' a ', **other_kwargs))
+        self.assertEqual(
+            cm.exception.args,
+            ("Value must not have leading or trailing whitespace.", ))
+
     def test_parse_rcv_compra_registro_csv_file(self) -> None:
         # TODO: implement for 'parse_rcv_compra_registro_csv_file'.
         pass
+
+    def test_fail_parse_rcv_compra_registro_csv_file_bad_razon_social(self) -> None:
+        other_kwargs = dict(rut=Rut('1-9'), input_file_path='x')
+
+        with self.assertRaises(TypeError) as cm:
+            next(parse_rcv_compra_registro_csv_file(razon_social=1, **other_kwargs))
+        self.assertEqual(cm.exception.args, ("Inappropriate type of 'razon_social'.", ))
+
+        with self.assertRaises(ValueError) as cm:
+            next(parse_rcv_compra_registro_csv_file(razon_social='', **other_kwargs))
+        self.assertEqual(cm.exception.args, ("Value must not be empty.", ))
+
+        with self.assertRaises(ValueError) as cm:
+            next(parse_rcv_compra_registro_csv_file(razon_social=' a ', **other_kwargs))
+        self.assertEqual(
+            cm.exception.args,
+            ("Value must not have leading or trailing whitespace.", ))
 
     def test_parse_rcv_compra_no_incluir_csv_file(self) -> None:
         # TODO: implement for 'parse_rcv_compra_no_incluir_csv_file'.
         pass
 
+    def test_fail_parse_rcv_compra_no_incluir_csv_file_bad_razon_social(self) -> None:
+        other_kwargs = dict(rut=Rut('1-9'), input_file_path='x')
+
+        with self.assertRaises(TypeError) as cm:
+            next(parse_rcv_compra_no_incluir_csv_file(razon_social=1, **other_kwargs))
+        self.assertEqual(cm.exception.args, ("Inappropriate type of 'razon_social'.", ))
+
+        with self.assertRaises(ValueError) as cm:
+            next(parse_rcv_compra_no_incluir_csv_file(razon_social='', **other_kwargs))
+        self.assertEqual(cm.exception.args, ("Value must not be empty.", ))
+
+        with self.assertRaises(ValueError) as cm:
+            next(parse_rcv_compra_no_incluir_csv_file(razon_social=' a ', **other_kwargs))
+        self.assertEqual(
+            cm.exception.args,
+            ("Value must not have leading or trailing whitespace.", ))
+
     def test_parse_rcv_compra_reclamado_csv_file(self) -> None:
         # TODO: implement for 'parse_rcv_compra_reclamado_csv_file'.
         pass
 
+    def test_fail_parse_rcv_compra_reclamado_csv_file_bad_razon_social(self) -> None:
+        other_kwargs = dict(rut=Rut('1-9'), input_file_path='x')
+
+        with self.assertRaises(TypeError) as cm:
+            next(parse_rcv_compra_reclamado_csv_file(razon_social=1, **other_kwargs))
+        self.assertEqual(cm.exception.args, ("Inappropriate type of 'razon_social'.", ))
+
+        with self.assertRaises(ValueError) as cm:
+            next(parse_rcv_compra_reclamado_csv_file(razon_social='', **other_kwargs))
+        self.assertEqual(cm.exception.args, ("Value must not be empty.", ))
+
+        with self.assertRaises(ValueError) as cm:
+            next(parse_rcv_compra_reclamado_csv_file(razon_social=' a ', **other_kwargs))
+        self.assertEqual(
+            cm.exception.args,
+            ("Value must not have leading or trailing whitespace.", ))
+
     def test_parse_rcv_compra_pendiente_csv_file(self) -> None:
         # TODO: implement for 'parse_rcv_compra_pendiente_csv_file'.
         pass
+
+    def test_fail_parse_rcv_compra_pendiente_csv_file_bad_razon_social(self) -> None:
+        other_kwargs = dict(rut=Rut('1-9'), input_file_path='x')
+
+        with self.assertRaises(TypeError) as cm:
+            next(parse_rcv_compra_pendiente_csv_file(razon_social=1, **other_kwargs))
+        self.assertEqual(cm.exception.args, ("Inappropriate type of 'razon_social'.", ))
+
+        with self.assertRaises(ValueError) as cm:
+            next(parse_rcv_compra_pendiente_csv_file(razon_social='', **other_kwargs))
+        self.assertEqual(cm.exception.args, ("Value must not be empty.", ))
+
+        with self.assertRaises(ValueError) as cm:
+            next(parse_rcv_compra_pendiente_csv_file(razon_social=' a ', **other_kwargs))
+        self.assertEqual(
+            cm.exception.args,
+            ("Value must not have leading or trailing whitespace.", ))
 
     def test__parse_rcv_csv_file(self) -> None:
         # TODO: implement for '_parse_rcv_csv_file'.


### PR DESCRIPTION
In parse functions (`parse_rcv_X_csv_file`).

Fixes #65.