### PR TITLE
libs.tz_utils: Fix setting of time zone information in datetimes

### DIFF
--- a/cl_sii/libs/tz_utils.py
+++ b/cl_sii/libs/tz_utils.py
@@ -43,6 +43,11 @@ def get_now_tz_aware() -> datetime:
     #   - `pytz.UTC.localize(datetime.utcnow())`
 
     # source: 'django.utils.timezone.now' @ Django 2.1.3
+    # warning: setting 'tzinfo' does not work for many timezones. To be safe, only use it for UTC
+    #   and None.
+    #   > Unfortunately using the tzinfo argument of the standard datetime constructors
+    #   > "does not work" with pytz for many timezones.
+    #   https://pythonhosted.org/pytz/#localized-times-and-date-arithmetic
     return datetime.utcnow().replace(tzinfo=TZ_UTC)
 
 
@@ -74,6 +79,8 @@ def convert_naive_dt_to_tz_aware(dt: datetime, tz: PytzTimezone) -> datetime:
     :raises ValueError: if ``dt`` is already timezone-aware
 
     """
+    # equivalent to:
+    #   dt.astimezone(tz)
     dt_tz_aware = tz.localize(dt)  # type: datetime
     return dt_tz_aware
 

--- a/cl_sii/rcv/data_models.py
+++ b/cl_sii/rcv/data_models.py
@@ -76,8 +76,9 @@ class PeriodoTributario:
 
     def as_datetime(self) -> datetime:
         # note: timezone-aware
-        return datetime(self.year, self.month, day=1, hour=0, minute=0, second=0).replace(
-            tzinfo=SII_OFFICIAL_TZ)
+        return tz_utils.convert_naive_dt_to_tz_aware(
+            datetime(self.year, self.month, day=1, hour=0, minute=0, second=0),
+            SII_OFFICIAL_TZ)
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
Python datetime objects require special care when setting their time zone information. Under certain conditions, `datetime.datetime.replace(tzinfo=TZ)` and `datetime.datetime(tzinfo=TZ)` may produce incorrect results.