### PR TITLE
extras: Handle `str`-typed RUTs in `Django RutField.get_prep_value()`

### DIFF
--- a/cl_sii/extras/dj_model_fields.py
+++ b/cl_sii/extras/dj_model_fields.py
@@ -105,7 +105,7 @@ class RutField(django.db.models.Field):
         # note: there is no parent implementation, for performance reasons.
         return self.to_python(value)
 
-    def get_prep_value(self, value: Optional[Rut]) -> Optional[str]:
+    def get_prep_value(self, value: Optional[object]) -> Optional[str]:
         """
         Convert the model's attribute value to a format suitable for the DB.
 
@@ -115,9 +115,13 @@ class RutField(django.db.models.Field):
         However, these are preliminary non-DB specific value checks and
         conversions (otherwise customize :meth:`get_db_prep_value`).
 
+        Note: Before returning, ``value`` will be passed to :meth:`to_python` so that, if needed, it
+        will be converted to an instance of :class:`Rut`, which is very convenient in cases such
+        as when the type of ``value`` is :class:`str`.
         """
         value = super().get_prep_value(value)
-        return value if value is None else value.canonical
+        value_rut: Optional[Rut] = self.to_python(value)
+        return value_rut if value_rut is None else value_rut.canonical
 
     def to_python(self, value: Optional[object]) -> Optional[Rut]:
         """

--- a/tests/test_extras_dj_model_fields.py
+++ b/tests/test_extras_dj_model_fields.py
@@ -8,11 +8,23 @@ from cl_sii.extras.dj_model_fields import Rut, RutField
 class RutFieldTest(unittest.TestCase):
     valid_rut_canonical: str
     valid_rut_instance: Rut
+    valid_rut_verbose_leading_zero_lowercase: str
 
     @classmethod
     def setUpClass(cls) -> None:
         cls.valid_rut_canonical = '60803000-K'
         cls.valid_rut_instance = Rut(cls.valid_rut_canonical)
+        cls.valid_rut_verbose_leading_zero_lowercase = '060.803.000-k'
+
+    def test_get_prep_value_of_canonical_str(self) -> None:
+        prepared_value = RutField().get_prep_value(self.valid_rut_canonical)
+        self.assertIsInstance(prepared_value, str)
+        self.assertEqual(prepared_value, self.valid_rut_canonical)
+
+    def test_get_prep_value_of_non_canonical_str(self) -> None:
+        prepared_value = RutField().get_prep_value(self.valid_rut_verbose_leading_zero_lowercase)
+        self.assertIsInstance(prepared_value, str)
+        self.assertEqual(prepared_value, self.valid_rut_canonical)
 
     def test_get_prep_value_of_Rut(self) -> None:
         prepared_value = RutField().get_prep_value(self.valid_rut_instance)

--- a/tests/test_extras_dj_model_fields.py
+++ b/tests/test_extras_dj_model_fields.py
@@ -2,11 +2,23 @@ import unittest
 
 import django.db.models  # noqa: F401
 
-from cl_sii.extras.dj_model_fields import Rut, RutField  # noqa: F401
+from cl_sii.extras.dj_model_fields import Rut, RutField
 
 
 class RutFieldTest(unittest.TestCase):
+    valid_rut_canonical: str
+    valid_rut_instance: Rut
 
-    # TODO: implement!
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.valid_rut_canonical = '60803000-K'
+        cls.valid_rut_instance = Rut(cls.valid_rut_canonical)
 
-    pass
+    def test_get_prep_value_of_Rut(self) -> None:
+        prepared_value = RutField().get_prep_value(self.valid_rut_instance)
+        self.assertIsInstance(prepared_value, str)
+        self.assertEqual(prepared_value, self.valid_rut_canonical)
+
+    def test_get_prep_value_of_None(self) -> None:
+        prepared_value = RutField().get_prep_value(None)
+        self.assertIsNone(prepared_value)


### PR DESCRIPTION
The method `cl_sii.extras.dj_model_fields.RutField.get_prep_value(value)`
expects a `Rut`-typed R.U.T. `value`, which usually is fine.

However, when executing a query, it may be sometimes desirable to pass the
R.U.T. value as a string rather than as an instance of the `Rut` class.

For example, when using the Django Shell, it is more convenient to type
`ExampleModel.objects.get(rut='60803000-K')` than
`ExampleModel.objects.get(rut=Rut('60803000-K'))`, because the former avoids
needing to import the `Rut` class and is quicker to type. The same thing goes
for instances of the `uuid.UUID` class.

Before this commit, the `str`-typed R.U.T. would raise an `AttributeError`,
because `django.db.models.lookups.Lookup.get_prep_lookup()` passes the string to
`RutField.get_prep_value(value)` without first converting it to a `Rut`
instance.